### PR TITLE
fix: ranking tied position

### DIFF
--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { collection, getDocs, query, orderBy, where } from 'firebase/firestore';
 
+import { GAME_STATUS } from 'constants/types';
 import { DAILY_RESULTS } from 'firebase/collections';
 import firebaseData from 'firebase/firebase';
 import { getTodaysDate } from 'utils/helpers';
@@ -25,16 +26,25 @@ const useRankingData = () => {
         where('formattedDate', '==', today),
         orderBy('attempts'),
         orderBy('status', 'desc'),
-        orderBy('date')
+        orderBy('user.name')
       );
       const docs = await getDocs(q);
       const results = [];
+      let position = 0;
+      let currentAttempts = 0;
+      let currentStatus = GAME_STATUS.won;
       docs.forEach(doc => {
         const { attemptedWords, attempts, formattedDate, status, user } = doc.data();
+        if (currentAttempts !== attempts || currentStatus !== status) {
+          currentAttempts = attempts;
+          currentStatus = status;
+          position += 1;
+        }
         results.push({
           attemptedWords,
           attempts,
           formattedDate,
+          position,
           status,
           user,
         });

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -28,12 +28,12 @@ const Ranking = () => {
                 key={`${email}-${attempts}`}
                 className={cn('daily-data-container', { isCurrentUser, lost })}
               >
-                <p className="daily-position">{position}</p>
+                <span className="daily-position">{position}</span>
                 <div className="daily-data-user">
                   <img src={photo} className="daily-data-photo" alt="user" />
-                  <p className="daily-data-name">{name}</p>
+                  <span className="daily-data-name">{name}</span>
                 </div>
-                <p className="daily-data-attempts">{lost ? 'X' : attempts}</p>
+                <span className="daily-data-attempts">{lost ? 'X' : attempts}</span>
               </div>
             );
           })}

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -1,7 +1,6 @@
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import 'react-tabs/style/react-tabs.css';
 import cn from 'classnames';
-import ReplayIcon from '@mui/icons-material/Replay';
 
 import { GAME_STATUS } from 'constants/types';
 import useRankingData from 'hooks/useRankingData';
@@ -20,7 +19,7 @@ const Ranking = () => {
           <Tab>All Time Average</Tab>
         </TabList>
         <TabPanel>
-          {dailyResults.map(({ attempts, status, user: { email, name, photo } }, index) => {
+          {dailyResults.map(({ attempts, position, status, user: { email, name, photo } }) => {
             const isCurrentUser = email === currentUser;
             const lost = status === GAME_STATUS.lost;
 
@@ -29,15 +28,12 @@ const Ranking = () => {
                 key={`${email}-${attempts}`}
                 className={cn('daily-data-container', { isCurrentUser, lost })}
               >
-                <p className="daily-position">{index + 1}</p>
+                <p className="daily-position">{position}</p>
                 <div className="daily-data-user">
                   <img src={photo} className="daily-data-photo" alt="user" />
                   <p className="daily-data-name">{name}</p>
                 </div>
-                <div className="daily-data-attempts-container">
-                  <p className="daily-data-attempts">{attempts}</p>
-                  <ReplayIcon fontSize="small" />
-                </div>
+                <p className="daily-data-attempts">{lost ? 'X' : attempts}</p>
               </div>
             );
           })}

--- a/src/pages/Ranking/styles.css
+++ b/src/pages/Ranking/styles.css
@@ -82,6 +82,7 @@
   border-width: 2px;
   display: flex;
   margin: 15px 0;
+  padding: 10px 0;
 }
 
 .daily-data-container.isCurrentUser {

--- a/src/pages/Ranking/styles.css
+++ b/src/pages/Ranking/styles.css
@@ -122,13 +122,8 @@
   font-size: 20px;
 }
 
-.daily-data-attempts-container {
-  align-items: center;
-  display: flex;
-  flex: 0.15;
-}
-
 .daily-data-attempts {
+  flex: 0.15;
   font-size: 18px;
   padding-right: 7px;
 }


### PR DESCRIPTION
## Links:
[Arreglar posicion compartida en el ranking diario](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=Arreglar%20posicion%20compartida%20en%20el%20ranking%20diario)


## What & Why:
This PR fixes the ranking positions, now tied players share the position number. Also, now the lost status shows an X instead of a 6 and it doesn't have the icon next to the number

<img width="1217" alt="image" src="https://user-images.githubusercontent.com/8755889/204913020-e3df0774-61e6-4b6e-8553-c9c8a9322501.png">


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
