### PR TITLE
fix: delete behavior and arrows move left and right

### DIFF
--- a/src/constants/keyboardKeys.js
+++ b/src/constants/keyboardKeys.js
@@ -1,0 +1,4 @@
+export const ARROW_LEFT = 'ArrowLeft';
+export const ARROW_RIGHT = 'ArrowRight';
+export const BACKSPACE = 'Backspace';
+export const ENTER = 'Enter';

--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -3,6 +3,7 @@ import { addDoc, collection, getDocs, query, orderBy, where } from 'firebase/fir
 import wordExists from 'word-exists';
 
 import { COLOR_ORDER, KEYBOARD_LETTERS, MAX_ATTEMPTS, WORDLE_URL } from 'constants/constants';
+import { ARROW_LEFT, ARROW_RIGHT, BACKSPACE, ENTER } from 'constants/keyboardKeys';
 import { LETTER_STATUS, LETTER_STATUS_ICON, GAME_STATUS } from 'constants/types';
 import { USERS_ATTEMPTS, DAILY_RESULTS } from 'firebase/collections';
 import firebaseData from 'firebase/firebase';
@@ -284,20 +285,29 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
     ({ key }) => {
       setError('');
       if (gameEnded) return;
-      const isDelete = key === 'Backspace';
-      const isEnter = key === 'Enter';
+      const isArrowLeft = key === ARROW_LEFT;
+      const isArrowRight = key === ARROW_RIGHT;
+      const isDelete = key === BACKSPACE;
+      const isEnter = key === ENTER;
 
       if (key.length > 1 && !isDelete) {
         isEnter && onSubmitWord();
+        isArrowLeft && focusBefore(letterIndex);
+        isArrowRight && focusNext(letterIndex);
         return;
       }
       const isLetter = key.match(/[a-zA-Z]/g);
 
       if (isLetter || isDelete) {
         const newAttempt = [...usersAttempts];
+        const wasEmpty = !newAttempt[currentRound][letterIndex];
         newAttempt[currentRound][letterIndex] = isDelete ? '' : key.toUpperCase();
         setUsersAttempts(newAttempt);
-        isDelete ? focusBefore(letterIndex) : focusNext(letterIndex);
+        if (isDelete) {
+          wasEmpty && focusBefore(letterIndex);
+        } else {
+          focusNext(letterIndex);
+        }
       }
     },
     [currentRound, focusNext, gameEnded, letterIndex, onSubmitWord, usersAttempts]


### PR DESCRIPTION
## Links:
[Cambiar comportamiento de borrar letra](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=Analizar%20el%20funcionamiento%20de%20borrar%20letras%20que%20parece%20que%20es%20confuso%20que%20te%20lleve%20al%20espacio%20anterior)
[hacer que las flechas derecha/izquierda te muevan en la palabra](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=hacer%20que%20las%20flechas%20derecha/izquierda%20te%20muevan%20en%20la%20palabra)

## What & Why:
This PR changes the behavior of the delete key. Now it only goes to the space before if it was empty, otherwise it deletes the letter but stays in the same position. 

It also adds the ability to move between letters with the right/left arrows keys.

![](http://g.recordit.co/i27UEE9fKB.gif)


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
