### PR TITLE
fix: paint selected menu option

### DIFF
--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -25,14 +25,20 @@ const SideNav = () => {
         </button>
         {navData.map(item =>
           item.id !== settingsIndex ? (
-            <NavLink key={item.id} className="sideitem" to={item.link}>
+            <NavLink
+              key={item.id}
+              className="sideitem"
+              activeClassName="selected-item"
+              to={item.link}
+              exact={item.exact}
+            >
               {item.icon}
               <span className={cn('sidenav-link-text', { closed: !open })}>{item.text}</span>
             </NavLink>
           ) : null
         )}
       </div>
-      <NavLink className="sideitem" to={settings.link}>
+      <NavLink className="sideitem" activeClassName="selected-item" to={settings.link}>
         {settings.icon}
         <span className={cn('sidenav-link-text', { closed: !open })}>{settings.text}</span>
       </NavLink>

--- a/src/components/SideNav/navData.js
+++ b/src/components/SideNav/navData.js
@@ -39,11 +39,13 @@ export const navData = [
     icon: <InfoIcon />,
     text: 'Rules',
     link: '/rules',
+    exact: true,
   },
   {
     id: 5,
     icon: <SettingsIcon />,
     text: 'Settings',
     link: '/settings',
+    exact: true,
   },
 ];

--- a/src/components/SideNav/navData.js
+++ b/src/components/SideNav/navData.js
@@ -11,6 +11,7 @@ export const navData = [
     icon: <HomeIcon />,
     text: 'Home',
     link: '/',
+    exact: true,
   },
   {
     id: 1,

--- a/src/components/SideNav/navData.js
+++ b/src/components/SideNav/navData.js
@@ -18,18 +18,21 @@ export const navData = [
     icon: <LeaderboardIcon />,
     text: 'Ranking',
     link: '/ranking',
+    exact: true,
   },
   {
     id: 2,
     icon: <ShowChartIcon />,
     text: 'Statistics',
     link: '/statistics',
+    exact: true,
   },
   {
     id: 3,
     icon: <GroupIcon />,
     text: 'Users',
     link: '/users',
+    exact: true,
   },
   {
     id: 4,

--- a/src/components/SideNav/sidenav.css
+++ b/src/components/SideNav/sidenav.css
@@ -4,7 +4,7 @@
   justify-content: space-between;
   width: 250px;
   transition: width 0.3s ease-in-out;
-  background-color: #538d4e;
+  background-color: var(--color-green);
   padding: 28px 0 18px;
 }
 
@@ -17,7 +17,7 @@
   align-items: center;
   padding: 10px 20px;
   cursor: pointer;
-  color: white;
+  color: var(--color-white);
   text-decoration: none;
 }
 
@@ -30,12 +30,16 @@
 }
 
 .sideitem:hover {
-  background-color: #244f7d1c;
+  background-color: var(--color-background);
+}
+
+.selected-item {
+  background-color: var(--color-background);
 }
 
 .menuBtn {
-  color: white;
-  background-color: transparent;
+  color: var(--color-white);
+  background-color: var(--color-transparent);
   border: none;
   cursor: pointer;
   padding-left: 20px;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,4 +1,5 @@
 :root {
+  --color-background: #1a1a1b;
   --color-black: #1f1f1f;
   --color-light-black: #303030;
   --color-light-grey: #d3d3d3;
@@ -9,6 +10,7 @@
   --color-medium-red: rgba(210, 62, 62, 0.5);
   --color-red: #d23e3e;
   --color-light-blue: #278ed3;
+  --color-transparent: transparent;
   --box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, 0.2);
 
   --font-size: 14px;


### PR DESCRIPTION
## Links:
[Pintar la opcion de menu donde estas actualmente de otro color](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=Pintar%20la%20opcion%20de%20menu%20donde%20estas%20actualmente%20de%20otro%20color)


## What & Why:
This PR paints the selected option in the nav bar menu, so the user can know which option is selected. Is the same color used on hover.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8755889/209015739-b8352791-8c5c-4163-b106-855b25516cbe.png">


<img width="1428" alt="image" src="https://user-images.githubusercontent.com/8755889/209016052-d4747e41-8a50-4403-807c-a88ce245a9b3.png">



## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
