### PR TITLE
fix: losing statistics error

### DIFF
--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -182,9 +182,10 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
           },
         });
 
+        const totalAttemptsIndex = won ? currentRound : currentRound + 1;
         const newCurrentStreak = won ? currentStreak + 1 : 0;
         const newTotalAttempts = [...totalAttempts];
-        newTotalAttempts[won ? currentRound : currentRound + 1] = totalAttempts[currentRound] + 1;
+        newTotalAttempts[totalAttemptsIndex] = totalAttempts[totalAttemptsIndex] + 1;
         const newAttemptedWords = { ...attemptedWords };
         usersAttempts.forEach(attempt => {
           const word = attempt.join('');


### PR DESCRIPTION
## Links:

[Bug de que las estadisticas se actualizan mal cuando uno pierde](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=Investigar%20por%20que%20cuando%20pierdo%20no%20me%20suma%20uno%20en%20perdidos%20sino%20que%20resetea%20a%201%20sola%20perdida)


## What & Why:

This PR fixes a bug that when you lost the lost attempts were wrongly counted. 


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
