### PR TITLE
fix: ranking words alignment

### DIFF
--- a/src/pages/Ranking/styles.css
+++ b/src/pages/Ranking/styles.css
@@ -85,8 +85,10 @@
 
 .daily-data-word {
   border-radius: 10px;
+  height: 18px;
   margin: 5px;
   padding: 5px 10px;
+  width: 12px;
 }
 
 .daily-data-words.isExpanded {


### PR DESCRIPTION
## Links:

[hacer que las letras esten bien alineadas en las palabras del ranking](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=hacer%20que%20las%20letras%20esten%20bien%20alineadas%20en%20las%20palabras%20del%20ranking)


## What & Why:

This PR fixes the alignment in the words shown in the ranking.

Before:

![image](https://user-images.githubusercontent.com/8755889/209194153-d64a17af-f4c4-4100-96ca-5e9c478e91ff.png)

After:

![image](https://user-images.githubusercontent.com/8755889/209194178-28fbbde6-0b95-4c32-94a8-c573c6647784.png)


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
