### PR TITLE
feat: add different rankings in the All Time tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^7.2.3",
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
+    "react-select": "^5.7.0",
     "react-tabs": "^5.1.0",
     "reactjs-flip-card": "^2.0.0",
     "redux-logger": "^3.0.6",

--- a/src/components/common/Select/index.js
+++ b/src/components/common/Select/index.js
@@ -3,27 +3,47 @@ import SelectReact from 'react-select';
 
 import './styles.css';
 
-const backgroundColor = 'rgba(83, 141, 78, 0.85)';
+const activeColor = '#3d6b39';
+const backgroundColor = '#538d4e';
+const color = 'white';
+const focusedColor = '#3d6b39';
+const hoverColor = '#c6d4c5';
+const selectedColor = '#1f1f1f';
 
 const Select = ({ ...props }) => {
   const colorStyles = {
-    control: styles => ({
+    control: (styles, { isFocused }) => ({
       ...styles,
       backgroundColor: backgroundColor,
-      borderColor: backgroundColor,
+      borderColor: isFocused ? color : backgroundColor,
+      borderWidth: 2,
+
+      ':hover': {
+        ...styles[':hover'],
+        borderColor: color,
+      },
     }),
+    dropdownIndicator: styles => ({
+      ...styles,
+      color,
+
+      ':hover': {
+        ...styles[':hover'],
+        color: hoverColor,
+      },
+    }),
+    menu: styles => ({ ...styles, backgroundColor }),
     option: (styles, { isFocused, isSelected }) => ({
       ...styles,
-      backgroundColor: isSelected ? '#1f1f1f' : backgroundColor,
-      opacity: isFocused && !isSelected ? 0.7 : 1,
-      color: 'white',
+      backgroundColor: isSelected ? selectedColor : isFocused ? focusedColor : backgroundColor,
+      color,
 
       ':active': {
         ...styles[':active'],
-        backgroundColor: 'red',
+        backgroundColor: activeColor,
       },
     }),
-    singleValue: styles => ({ ...styles, color: 'white' }),
+    singleValue: styles => ({ ...styles, color }),
   };
   return <SelectReact {...props} styles={colorStyles} />;
 };

--- a/src/components/common/Select/index.js
+++ b/src/components/common/Select/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import SelectReact from 'react-select';
+
+import './styles.css';
+
+const backgroundColor = 'rgba(83, 141, 78, 0.85)';
+
+const Select = ({ ...props }) => {
+  const colorStyles = {
+    control: styles => ({
+      ...styles,
+      backgroundColor: backgroundColor,
+      borderColor: backgroundColor,
+    }),
+    option: (styles, { isFocused, isSelected }) => ({
+      ...styles,
+      backgroundColor: isSelected ? '#1f1f1f' : backgroundColor,
+      opacity: isFocused && !isSelected ? 0.7 : 1,
+      color: 'white',
+
+      ':active': {
+        ...styles[':active'],
+        backgroundColor: 'red',
+      },
+    }),
+    singleValue: styles => ({ ...styles, color: 'white' }),
+  };
+  return <SelectReact {...props} styles={colorStyles} />;
+};
+
+export default Select;

--- a/src/components/common/Select/index.js
+++ b/src/components/common/Select/index.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import SelectReact from 'react-select';
 
-import './styles.css';
-
-const activeColor = '#3d6b39';
+const activeColor = '#1f1f1f';
 const backgroundColor = '#538d4e';
 const color = 'white';
-const focusedColor = '#3d6b39';
+const focusedColor = '#1f1f1f';
 const hoverColor = '#c6d4c5';
-const selectedColor = '#1f1f1f';
+const selectedColor = '#3d6b39';
 
 const Select = ({ ...props }) => {
   const colorStyles = {
+    container: styles => ({
+      ...styles,
+      marginBottom: 35,
+    }),
     control: (styles, { isFocused }) => ({
       ...styles,
       backgroundColor: backgroundColor,

--- a/src/constants/types.js
+++ b/src/constants/types.js
@@ -16,3 +16,18 @@ export const GAME_STATUS = {
   playing: 'playing',
   won: 'won',
 };
+
+export const RANKING_VALUES = [
+  {
+    value: 'currentStreak',
+    label: 'Current Streak',
+    getValueToShow: currentStreak => currentStreak,
+    color: 'green',
+  },
+  {
+    value: 'longestStreak',
+    label: 'Longest Streak',
+    getValueToShow: longestStreak => longestStreak,
+    color: 'green',
+  },
+];

--- a/src/constants/types.js
+++ b/src/constants/types.js
@@ -21,11 +21,46 @@ export const RANKING_VALUES = [
   {
     value: 'currentStreak',
     label: 'Current Streak',
-    getDisplayValue: ({ currentStreak }) => currentStreak,
+    getNumericValue: ({ currentStreak }) => currentStreak,
+    getRightText: ({ currentStreak }) => `${currentStreak} 🔥`,
+    getSuffix: ({ lastDatePlayed }) => `(${lastDatePlayed})`,
   },
   {
     value: 'longestStreak',
     label: 'Longest Streak',
-    getDisplayValue: ({ longestStreak }) => longestStreak,
+    getNumericValue: ({ longestStreak }) => longestStreak,
+    getRightText: ({ longestStreak }) => `${longestStreak} 🔥`,
+    getSuffix: ({ longestStreakDate }) => `(${longestStreakDate})`,
+  },
+  {
+    value: 'numberOfGames',
+    label: 'Number of Games',
+    getNumericValue: ({ totalGames }) => totalGames,
+    getRightText: ({ totalGames }) => totalGames,
+    getSuffix: () => '',
+  },
+  {
+    value: 'totalWins',
+    label: 'Total Wins',
+    getNumericValue: ({ totalWins }) => totalWins,
+    getRightText: ({ totalWins }) => `${totalWins} 🎉`,
+    getSuffix: () => '',
+  },
+  {
+    value: 'totalLosses',
+    label: 'Total Losses',
+    getNumericValue: ({ totalGames, totalWins }) => totalGames - totalWins,
+    getRightText: ({ totalGames, totalWins }) =>
+      `${totalGames - totalWins} ${totalGames > totalWins ? '😢' : '😌'}`,
+    getSuffix: () => '',
+  },
+  {
+    value: 'winsPercentage',
+    label: 'Wins (%)',
+    getNumericValue: ({ totalGames, totalWins }) =>
+      totalGames ? ((totalWins * 100) / totalGames).toFixed(0) : 0,
+    getRightText: ({ totalGames, totalWins }) =>
+      `${totalGames ? ((totalWins * 100) / totalGames).toFixed(0) : 0} %`,
+    getSuffix: () => '',
   },
 ];

--- a/src/constants/types.js
+++ b/src/constants/types.js
@@ -24,6 +24,7 @@ export const RANKING_VALUES = [
     getNumericValue: ({ currentStreak }) => currentStreak,
     getRightText: ({ currentStreak }) => `${currentStreak} 🔥`,
     getSuffix: ({ lastDatePlayed }) => `(${lastDatePlayed})`,
+    sort: (firstValue, secondValue) => secondValue - firstValue,
   },
   {
     value: 'longestStreak',
@@ -31,6 +32,7 @@ export const RANKING_VALUES = [
     getNumericValue: ({ longestStreak }) => longestStreak,
     getRightText: ({ longestStreak }) => `${longestStreak} 🔥`,
     getSuffix: ({ longestStreakDate }) => `(${longestStreakDate})`,
+    sort: (firstValue, secondValue) => secondValue - firstValue,
   },
   {
     value: 'numberOfGames',
@@ -38,6 +40,7 @@ export const RANKING_VALUES = [
     getNumericValue: ({ totalGames }) => totalGames,
     getRightText: ({ totalGames }) => totalGames,
     getSuffix: () => '',
+    sort: (firstValue, secondValue) => secondValue - firstValue,
   },
   {
     value: 'totalWins',
@@ -45,6 +48,7 @@ export const RANKING_VALUES = [
     getNumericValue: ({ totalWins }) => totalWins,
     getRightText: ({ totalWins }) => `${totalWins} 🎉`,
     getSuffix: () => '',
+    sort: (firstValue, secondValue) => secondValue - firstValue,
   },
   {
     value: 'totalLosses',
@@ -53,6 +57,7 @@ export const RANKING_VALUES = [
     getRightText: ({ totalGames, totalWins }) =>
       `${totalGames - totalWins} ${totalGames > totalWins ? '😢' : '😌'}`,
     getSuffix: () => '',
+    sort: (firstValue, secondValue) => firstValue - secondValue,
   },
   {
     value: 'winsPercentage',
@@ -62,5 +67,6 @@ export const RANKING_VALUES = [
     getRightText: ({ totalGames, totalWins }) =>
       `${totalGames ? ((totalWins * 100) / totalGames).toFixed(0) : 0} %`,
     getSuffix: () => '',
+    sort: (firstValue, secondValue) => secondValue - firstValue,
   },
 ];

--- a/src/constants/types.js
+++ b/src/constants/types.js
@@ -22,12 +22,10 @@ export const RANKING_VALUES = [
     value: 'currentStreak',
     label: 'Current Streak',
     getValueToShow: currentStreak => currentStreak,
-    color: 'green',
   },
   {
     value: 'longestStreak',
     label: 'Longest Streak',
     getValueToShow: longestStreak => longestStreak,
-    color: 'green',
   },
 ];

--- a/src/constants/types.js
+++ b/src/constants/types.js
@@ -21,11 +21,11 @@ export const RANKING_VALUES = [
   {
     value: 'currentStreak',
     label: 'Current Streak',
-    getValueToShow: currentStreak => currentStreak,
+    getDisplayValue: ({ currentStreak }) => currentStreak,
   },
   {
     value: 'longestStreak',
     label: 'Longest Streak',
-    getValueToShow: longestStreak => longestStreak,
+    getDisplayValue: ({ longestStreak }) => longestStreak,
   },
 ];

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -111,20 +111,23 @@ const useRankingData = () => {
       let currentValue = Number.MAX_SAFE_INTEGER;
       newRankingData = newRankingData
         .sort((firstValue, secondValue) => {
-          if (secondValue[newValue.value] === firstValue[newValue.value]) {
+          const firstDisplayValue = newValue.getDisplayValue(firstValue);
+          const secondDisplayValue = newValue.getDisplayValue(secondValue);
+          if (firstDisplayValue === secondDisplayValue) {
             if (firstValue.user.name < secondValue.user.name) return -1;
             return firstValue.user.name > secondValue.user.name ? 1 : 0;
           }
-          return secondValue[newValue.value] - firstValue[newValue.value];
+          return secondDisplayValue - firstDisplayValue;
         })
         .map(item => {
-          if (item[newValue.value] !== currentValue) {
-            currentValue = item[newValue.value];
+          const displayValue = newValue.getDisplayValue(item);
+          if (displayValue !== currentValue) {
+            currentValue = displayValue;
             position += 1;
           }
           return {
             ...item,
-            displayValue: item[newValue.value],
+            displayValue,
             position,
           };
         });

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -121,7 +121,7 @@ const useRankingData = () => {
   const onChangeSelectedRanking = newSelectedRanking => {
     if (newSelectedRanking !== selectedRanking) {
       setSelectedRanking(newSelectedRanking);
-      var newRankingData = [...rankingData];
+      let newRankingData = [...rankingData];
       let position = 0;
       let currentValue = Number.MAX_SAFE_INTEGER;
       newRankingData = newRankingData

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -132,12 +132,12 @@ const useRankingData = () => {
             if (firstValue.user.name < secondValue.user.name) return -1;
             return firstValue.user.name > secondValue.user.name ? 1 : 0;
           }
-          return secondRightText - firstRightText;
+          return newSelectedRanking.sort(firstRightText, secondRightText);
         })
         .map(item => {
-          const rightText = newSelectedRanking.getNumericValue(item);
-          if (rightText !== currentValue) {
-            currentValue = rightText;
+          const numericValue = newSelectedRanking.getNumericValue(item);
+          if (numericValue !== currentValue) {
+            currentValue = numericValue;
             position += 1;
           }
           return {

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -84,7 +84,7 @@ const useRankingData = () => {
       let currentStreakValue = Number.MAX_SAFE_INTEGER;
       docs.forEach(async doc => {
         const { id: userEmail } = doc;
-        const { currentStreak, totalGames, ...restStatistics } = doc.data();
+        const { currentStreak, lastDatePlayed, totalGames, ...restStatistics } = doc.data();
         if (!!totalGames) {
           if (currentStreak !== currentStreakValue) {
             currentStreakValue = currentStreak;
@@ -93,7 +93,10 @@ const useRankingData = () => {
           results.push({
             ...restStatistics,
             currentStreak,
-            displayValue: currentStreak,
+            lastDatePlayed,
+            rightText: RANKING_VALUES[0].getRightText({ currentStreak }),
+            suffix: RANKING_VALUES[0].getSuffix({ lastDatePlayed }),
+            totalGames,
             position,
             user: users[userEmail] || { email: userEmail, name: userEmail.split('@')[0] },
           });
@@ -115,31 +118,32 @@ const useRankingData = () => {
       state: { email, name, photo },
     });
 
-  const onChangeSelectedRanking = newValue => {
-    if (newValue !== selectedRanking) {
-      setSelectedRanking(newValue);
+  const onChangeSelectedRanking = newSelectedRanking => {
+    if (newSelectedRanking !== selectedRanking) {
+      setSelectedRanking(newSelectedRanking);
       var newRankingData = [...rankingData];
       let position = 0;
       let currentValue = Number.MAX_SAFE_INTEGER;
       newRankingData = newRankingData
         .sort((firstValue, secondValue) => {
-          const firstDisplayValue = newValue.getDisplayValue(firstValue);
-          const secondDisplayValue = newValue.getDisplayValue(secondValue);
-          if (firstDisplayValue === secondDisplayValue) {
+          const firstRightText = newSelectedRanking.getNumericValue(firstValue);
+          const secondRightText = newSelectedRanking.getNumericValue(secondValue);
+          if (firstRightText === secondRightText) {
             if (firstValue.user.name < secondValue.user.name) return -1;
             return firstValue.user.name > secondValue.user.name ? 1 : 0;
           }
-          return secondDisplayValue - firstDisplayValue;
+          return secondRightText - firstRightText;
         })
         .map(item => {
-          const displayValue = newValue.getDisplayValue(item);
-          if (displayValue !== currentValue) {
-            currentValue = displayValue;
+          const rightText = newSelectedRanking.getNumericValue(item);
+          if (rightText !== currentValue) {
+            currentValue = rightText;
             position += 1;
           }
           return {
             ...item,
-            displayValue,
+            rightText: newSelectedRanking.getRightText(item),
+            suffix: newSelectedRanking.getSuffix(item),
             position,
           };
         });

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -21,11 +21,13 @@ const Ranking = () => {
   const {
     currentUser,
     currentUserPlayed,
-    currentStreakRankingData,
+    rankingData,
     dailyResults,
     expandedUser,
     setExpandedUser,
     loading,
+    selectedRanking,
+    onChangeSelectedRanking,
   } = useRankingData();
 
   return (
@@ -37,7 +39,7 @@ const Ranking = () => {
         <Tabs className="Tabs">
           <TabList>
             <Tab>{`Today (${dailyResults.length})`}</Tab>
-            <Tab>{`Current Streak (${currentStreakRankingData.length})`}</Tab>
+            <Tab>{`All Time (${rankingData.length})`}</Tab>
           </TabList>
           <TabPanel>
             {dailyResults.map(
@@ -93,23 +95,23 @@ const Ranking = () => {
           </TabPanel>
           <TabPanel>
             <>
-              <Select options={RANKING_VALUES} defaultValue={RANKING_VALUES[0]} />
-              {currentStreakRankingData.map(
-                ({
-                  currentStreak,
-                  lastDatePlayed,
-                  position,
-                  user: { email, name, photo, uid },
-                }) => {
+              <Select
+                options={RANKING_VALUES}
+                onChange={onChangeSelectedRanking}
+                value={selectedRanking}
+              />
+              {rankingData.map(
+                ({ displayValue, lastDatePlayed, position, user: { email, name, photo, uid } }) => {
                   const isCurrentUser = email === currentUser;
+
                   return (
                     <ListRow
-                      key={`${email}-${currentStreak}-current-streak`}
+                      key={`${email}-${displayValue}-${selectedRanking}`}
                       classProps={{ isCurrentUser }}
                       name={name}
                       photo={photo}
                       leftText={position}
-                      rightText={`${currentStreak} 🔥`}
+                      rightText={`${displayValue} 🔥`}
                       suffix={`(${lastDatePlayed})`}
                       showIcon={false}
                       onClick={() =>

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -99,13 +99,7 @@ const Ranking = () => {
                 value={selectedRanking}
               />
               {rankingData.map(
-                ({
-                  displayValue,
-                  lastDatePlayed,
-                  position,
-                  user: { email, name, photo },
-                  user,
-                }) => {
+                ({ position, rightText, suffix, user: { email, name, photo }, user }) => {
                   const isCurrentUser = email === currentUser;
 
                   return (
@@ -115,8 +109,8 @@ const Ranking = () => {
                       name={name}
                       photo={photo}
                       leftText={position}
-                      rightText={`${displayValue} 🔥`}
-                      suffix={`(${lastDatePlayed})`}
+                      rightText={rightText}
+                      suffix={suffix}
                       showIcon={false}
                       onClick={() => goToUsersStatistics(user)}
                     />

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -7,7 +7,8 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 import ListRow from 'components/common/ListRow';
 import Loading from 'components/common/Loading';
-import { GAME_STATUS } from 'constants/types';
+import Select from 'components/common/Select';
+import { GAME_STATUS, RANKING_VALUES } from 'constants/types';
 import useRankingData from 'hooks/useRankingData';
 
 import './styles.css';
@@ -91,29 +92,37 @@ const Ranking = () => {
             )}
           </TabPanel>
           <TabPanel>
-            {currentStreakRankingData.map(
-              ({ currentStreak, lastDatePlayed, position, user: { email, name, photo, uid } }) => {
-                const isCurrentUser = email === currentUser;
-                return (
-                  <ListRow
-                    key={`${email}-${currentStreak}-current-streak`}
-                    classProps={{ isCurrentUser }}
-                    name={name}
-                    photo={photo}
-                    leftText={position}
-                    rightText={`${currentStreak} 🔥`}
-                    suffix={`(${lastDatePlayed})`}
-                    showIcon={false}
-                    onClick={() =>
-                      push({
-                        pathname: `/statistics/${uid}`,
-                        state: { email, name, photo },
-                      })
-                    }
-                  />
-                );
-              }
-            )}
+            <>
+              <Select options={RANKING_VALUES} defaultValue={RANKING_VALUES[0]} />
+              {currentStreakRankingData.map(
+                ({
+                  currentStreak,
+                  lastDatePlayed,
+                  position,
+                  user: { email, name, photo, uid },
+                }) => {
+                  const isCurrentUser = email === currentUser;
+                  return (
+                    <ListRow
+                      key={`${email}-${currentStreak}-current-streak`}
+                      classProps={{ isCurrentUser }}
+                      name={name}
+                      photo={photo}
+                      leftText={position}
+                      rightText={`${currentStreak} 🔥`}
+                      suffix={`(${lastDatePlayed})`}
+                      showIcon={false}
+                      onClick={() =>
+                        push({
+                          pathname: `/statistics/${uid}`,
+                          state: { email, name, photo },
+                        })
+                      }
+                    />
+                  );
+                }
+              )}
+            </>
           </TabPanel>
         </Tabs>
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,6 +1058,13 @@
   dependencies:
     regenerator-runtime "^0.13.10"
 
+"@babel/runtime@^7.12.0":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
+  integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.10.4", "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -1133,7 +1140,7 @@
     source-map "^0.5.7"
     stylis "4.1.3"
 
-"@emotion/cache@^11.10.5":
+"@emotion/cache@^11.10.5", "@emotion/cache@^11.4.0":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
   integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
@@ -1161,7 +1168,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
-"@emotion/react@^11.10.5":
+"@emotion/react@^11.10.5", "@emotion/react@^11.8.1":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
   integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
@@ -1611,6 +1618,18 @@
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.8.1.tgz#5fbb3808677aa6b88bf79968237d3bb14595b1ba"
   integrity sha512-CJW8vxt6bJaBeco2VnlJjmCmAkrrtIdf0GGKvpAB4J5gw8Gi0rHb+qsgKp6LsyS5W6ALPLawLs7phZmw02dvLw==
+
+"@floating-ui/core@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.5.tgz#ada3cca622fe7b52d7b9ead97ddbed5b98925c66"
+  integrity sha512-iDdOsaCHZH/0FM0yNBYt+cJxJF9S5jrYWNtDZOiDFMiZ7uxMJ/71h8eTwoVifEAruv9p9rlMPYCGIgMjOz95FQ==
+
+"@floating-ui/dom@^1.0.1":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.0.tgz#29fea1344fdef15b6ba270a733d20b7134fee5c2"
+  integrity sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==
+  dependencies:
+    "@floating-ui/core" "^1.0.5"
 
 "@formatjs/ecma402-abstract@1.11.4":
   version "1.11.4"
@@ -2637,7 +2656,7 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-transition-group@^4.4.5":
+"@types/react-transition-group@^4.4.0", "@types/react-transition-group@^4.4.5":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
   integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
@@ -8295,6 +8314,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -10043,7 +10067,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.0, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10470,6 +10494,21 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
+react-select@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.0.tgz#82921b38f1fcf1471a0b62304da01f2896cd8ce6"
+  integrity sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^6.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.1.2"
+
 react-tabs@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-5.1.0.tgz#5ef8fad015c71c23b0fff65bd9b3bd419219c27b"
@@ -10478,7 +10517,7 @@ react-tabs@^5.1.0:
     clsx "^1.1.0"
     prop-types "^15.5.0"
 
-react-transition-group@^4.4.5:
+react-transition-group@^4.3.0, react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
   integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
@@ -10613,7 +10652,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
@@ -12261,6 +12300,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-isomorphic-layout-effect@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Links:

[tab All Time para el resto de los rankings](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=tab%20All%20Time%20para%20el%20resto%20de%20los%20rankings)


## What & Why:

This PR adds different types of ranking in the All Time tab. It makes it easy to add a new ranking option, just need to add an object in the `RANKING_VALUES` type with this format: 

```
 {
    value: 'value',
    label: 'label,
    getNumericValue: ({ interestedFieldsFromStatistics }) => calculatedValueWithInterestedFields,
    getRightText: ({ interestedFieldsFromStatistics }) => calculatedTextWithInterestedFields,
    getSuffix: ({ interestedFieldsFromStatistics }) => calculatedTextWithInterestedFields,
    sort: (firstValue, secondValue) => calculatedSortFunction,
  }
```

![](http://g.recordit.co/8pARGLynW4.gif)

## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
