### PR TITLE
refactor: remove users attempts and use daily results

### DIFF
--- a/src/firebase/collections.js
+++ b/src/firebase/collections.js
@@ -1,5 +1,4 @@
 export const WORDS_COLLECTION = 'words';
-export const USERS_ATTEMPTS = 'usersAttempts';
 export const DAILY_RESULTS = 'dailyResults';
 export const USERS_STATISTICS = 'usersStatistics';
 export const USERS = 'users';

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -44,18 +44,20 @@ const useRankingData = () => {
     (async function () {
       const q = query(
         collection(firebaseDb, DAILY_RESULTS),
-        where('formattedDate', '==', today),
-        orderBy('attempts'),
+        where('date', '==', today),
+        where('status', '!=', GAME_STATUS.playing),
         orderBy('status', 'desc'),
+        orderBy('attempts'),
         orderBy('user.name')
       );
       const docs = await getDocs(q);
+      console.log('docs: ', docs.docs);
       const results = [];
       let position = 0;
       let currentAttempts = 0;
       let currentStatus = GAME_STATUS.won;
       docs.forEach(doc => {
-        const { attemptedWords, attempts, formattedDate, status, user } = doc.data();
+        const { attemptedWords, attempts, date, status, user } = doc.data();
         if (currentAttempts !== attempts || currentStatus !== status) {
           currentAttempts = attempts;
           currentStatus = status;
@@ -64,7 +66,7 @@ const useRankingData = () => {
         results.push({
           attemptedWords,
           attempts,
-          formattedDate,
+          date,
           position,
           status,
           user,

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -51,25 +51,23 @@ const useRankingData = () => {
         orderBy('user.name')
       );
       const docs = await getDocs(q);
-      console.log('docs: ', docs.docs);
+
       const results = [];
       let position = 0;
       let currentAttempts = 0;
       let currentStatus = GAME_STATUS.won;
       docs.forEach(doc => {
-        const { attemptedWords, attempts, date, status, user } = doc.data();
+        const { attempts, status, ...restDailyResults } = doc.data();
         if (currentAttempts !== attempts || currentStatus !== status) {
           currentAttempts = attempts;
           currentStatus = status;
           position += 1;
         }
         results.push({
-          attemptedWords,
           attempts,
-          date,
-          position,
           status,
-          user,
+          ...restDailyResults,
+          position,
         });
       });
       setDailyResults(results);

--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -166,6 +166,7 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
       const won = correctCount === wordLength;
       const lost = usersAttempts.length === MAX_ATTEMPTS && !won;
       const newStatus = won ? GAME_STATUS.won : lost ? GAME_STATUS.lost : GAME_STATUS.playing;
+      const currentTime = getTodaysDate(false);
 
       if (!currentRound) {
         const newDailyResults = {
@@ -176,8 +177,8 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
             },
           ],
           attempts: 1,
-          startTime: '',
-          endTime: '',
+          startTime: currentTime,
+          endTime: currentTime,
           date: today,
           status: won ? GAME_STATUS.won : GAME_STATUS.playing,
           user: {
@@ -206,7 +207,7 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
           ...dailyResults,
           attemptedWords: newAttemptedWords,
           attempts: currentRound + 1,
-          // endTime: '',
+          endTime: currentTime,
           status: newStatus,
         };
 


### PR DESCRIPTION
## Links:

[pasar a usar daily results en vez de user attempts](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=pasar%20a%20usar%20daily%20results%20en%20vez%20de%20user%20attempts)


## What & Why:

This PR removes the use of usersAttempts collection and now only use dailyResults. Now with every new word tried, we modify the dailyResults doc instead of only adding there when it's finished.


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
