### PR TITLE
refactor: use user's timezone

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -7,7 +7,7 @@ const formatDate = dateTime => {
 };
 
 export const getTodaysDate = (shouldFormat = true) => {
-  const today = new Date().toISOString();
+  const today = new Date().toJSON();
 
   return shouldFormat ? formatDate(today) : today;
 };

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,15 +1,17 @@
 export const getRandomInt = max => Math.floor(Math.random() * max);
 
-const formatDate = dateTime => {
-  const [date] = dateTime.split('T');
+const formatDate = date => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
 
-  return date.split('-').join('');
+  return `${year}${month.toString().padStart(2, '0')}${day.toString().padStart(2, '0')}`;
 };
 
 export const getTodaysDate = (shouldFormat = true) => {
-  const today = new Date().toJSON();
+  const today = new Date();
 
-  return shouldFormat ? formatDate(today) : today;
+  return shouldFormat ? formatDate(today) : today.toString();
 };
 
 export const getTodaysDisplayDate = () => new Date().toLocaleString('en').split(',')[0];


### PR DESCRIPTION
## Links:

[hacer que el horario de nueva palabra sea 00 de tu pais y no de GMT 0](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=hacer%20que%20el%20horario%20de%20nueva%20palabra%20sea%2000%20de%20tu%20pais%20y%20no%20de%20GMT%200)


## What & Why:
This PR fixes the timezone, instead of using +0 it now we use the user's timezone

## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
