### PR TITLE
feat: add current streak to share results

### DIFF
--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -403,9 +403,7 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
       });
       textResult += '\n';
     });
-    textResult += '\n';
-    textResult += `Current Streak: ${currentStreak} ${getCurrentStreakIcon(currentStreak)}`;
-    textResult += '\n';
+    textResult += `\nCurrent Streak: ${currentStreak} ${getCurrentStreakIcon(currentStreak)}\n`;
     textResult += `\n${WORDLE_URL}`;
     await navigator.clipboard.writeText(textResult);
     alert('Copied to Clipboard: \n \n' + textResult);

--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -7,7 +7,12 @@ import { ARROW_LEFT, ARROW_RIGHT, BACKSPACE, ENTER } from 'constants/keyboardKey
 import { LETTER_STATUS, GAME_STATUS } from 'constants/types';
 import { DAILY_RESULTS } from 'firebase/collections';
 import firebaseData from 'firebase/firebase';
-import { getTodaysDate, getTodaysDisplayDate, getTimeDiff } from 'utils/helpers';
+import {
+  getCurrentStreakIcon,
+  getTodaysDate,
+  getTodaysDisplayDate,
+  getTimeDiff,
+} from 'utils/helpers';
 
 import useAuth from './useAuth';
 import useUserStatistics from './useUsersStatistics';
@@ -398,6 +403,9 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
       });
       textResult += '\n';
     });
+    textResult += '\n';
+    textResult += `Current Streak: ${currentStreak} ${getCurrentStreakIcon(currentStreak)}`;
+    textResult += '\n';
     textResult += `\n${WORDLE_URL}`;
     await navigator.clipboard.writeText(textResult);
     alert('Copied to Clipboard: \n \n' + textResult);

--- a/src/pages/Statistics/index.js
+++ b/src/pages/Statistics/index.js
@@ -33,7 +33,7 @@ const Statistics = () => {
               value={totalGames ? ((totalWins * 100) / totalGames).toFixed(0) : 0}
             />
             <StatBox label="Current Streak" value={currentStreak} />
-            <StatBox label="Max Streak" value={longestStreak} />
+            <StatBox label="Longest Streak" value={longestStreak} />
           </div>
           <div className="statistics-charts-container">
             <HorizontalBarChart data={totalAttempts} maxValue={maxAttemptsRound} />

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,20 @@
+export const getCurrentStreakIcon = currentStreak => {
+  let icon = '';
+  if (currentStreak < 10) icon = '🤍';
+  else if (currentStreak < 20) icon = '💛';
+  else if (currentStreak < 30) icon = '🧡';
+  else if (currentStreak < 40) icon = '💚';
+  else if (currentStreak < 50) icon = '💙';
+  else if (currentStreak < 60) icon = '💜';
+  else if (currentStreak < 70) icon = '🤎';
+  else if (currentStreak < 80) icon = '🖤';
+  else if (currentStreak < 90) icon = '❤️';
+  else if (currentStreak < 100) icon = '💖';
+  else icon = '❤️‍🔥';
+
+  return icon;
+};
+
 export const getRandomInt = max => Math.floor(Math.random() * max);
 
 const formatDate = date => {


### PR DESCRIPTION
## Links:

[Agregar current streak al compartir y cambiar max streak por longest streak en estadisticas](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=Agregar%20current%20streak%20al%20compartir%20y%20cambiar%20max%20streak%20por%20longest%20streak%20en%20estadisticas)


## What & Why:

This PR adds the current streak to the share results text. It has a different icon according to the current streak value. 

Share Results Example:

RS Wordle 1/3/2023 6/6 
 
⬜⬜⬜⬜⬜⬜
⬜⬜🟨⬜⬜🟩
🟨⬜⬜⬜🟨🟩
🟨🟨⬜⬜⬜⬜
🟩⬜🟨⬜🟨🟩
🟩🟩🟩🟩🟩🟩

Current Streak: 2 🤍

https://rs-wordle.netlify.app/


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
