### PR TITLE
feat: order ranking by solve time

### DIFF
--- a/src/components/common/ListRow/index.js
+++ b/src/components/common/ListRow/index.js
@@ -37,8 +37,11 @@ const ListRow = ({
           <img src={photo} className="list-row-photo" alt={`user-${name}`} />
           <span className="list-row-name">{name}</span>
         </div>
-        <span className="list-row-right-text">{rightText}</span>
-        {suffix && <span className="list-row-suffix">{suffix}</span>}
+        <div className="list-row-right-text-container">
+          <span className="list-row-right-text">{rightText}</span>
+          {suffix && showIcon && <span className="list-row-right-text-suffix">{suffix}</span>}
+        </div>
+        {suffix && !showIcon && <span className="list-row-suffix">{suffix}</span>}
         {showIcon && <div className="list-row-icon">{handleExpansion ? expandedIcon : icon}</div>}
       </button>
       <div

--- a/src/components/common/ListRow/styles.css
+++ b/src/components/common/ListRow/styles.css
@@ -60,10 +60,20 @@
   font-size: 20px;
 }
 
-.list-row-right-text {
+.list-row-right-text-container {
+  align-items: center;
+  display: flex;
   flex: 0.1;
+}
+
+.list-row-right-text {
   font-size: 18px;
   padding-right: 7px;
+}
+
+.list-row-right-text-suffix {
+  align-self: center;
+  width: 100%;
 }
 
 .list-row-suffix {

--- a/src/constants/types.js
+++ b/src/constants/types.js
@@ -1,3 +1,5 @@
+import { pluralize } from 'utils/helpers';
+
 export const LETTER_STATUS = {
   correct: {
     id: 'correct',
@@ -113,8 +115,7 @@ export const RANKING_VALUES = [
     },
     getSuffix: ({ totalAttempts }) => {
       const { commonAttemptValue } = getCommonAttempt({ totalAttempts });
-      const timesText = commonAttemptValue > 1 ? 'times' : 'time';
-      return `(${commonAttemptValue} ${timesText})`;
+      return `(${pluralize(commonAttemptValue, 'time')})`;
     },
     sort: (firstValue, secondValue) => firstValue - secondValue,
   },

--- a/src/constants/types.js
+++ b/src/constants/types.js
@@ -1,4 +1,4 @@
-import { pluralize } from 'utils/helpers';
+import { getCurrentStreakIcon, pluralize } from 'utils/helpers';
 
 export const LETTER_STATUS = {
   correct: {
@@ -66,8 +66,7 @@ export const RANKING_VALUES = [
     value: 'currentStreak',
     label: 'Current Streak',
     getNumericValue: ({ currentStreak }) => currentStreak,
-    getRightText: ({ currentStreak, isFirst }) =>
-      `${currentStreak} ${isFirst ? FIRST_EMOJI : '🔥'}`,
+    getRightText: ({ currentStreak }) => `${currentStreak} ${getCurrentStreakIcon(currentStreak)}`,
     getSuffix: ({ lastDatePlayed }) => `(${lastDatePlayed})`,
     sort: (firstValue, secondValue) => secondValue - firstValue,
   },
@@ -75,8 +74,7 @@ export const RANKING_VALUES = [
     value: 'longestStreak',
     label: 'Longest Streak',
     getNumericValue: ({ longestStreak }) => longestStreak,
-    getRightText: ({ isFirst, longestStreak }) =>
-      `${longestStreak} ${isFirst ? FIRST_EMOJI : '🔥'}`,
+    getRightText: ({ longestStreak }) => `${longestStreak} ${getCurrentStreakIcon(longestStreak)}`,
     getSuffix: ({ longestStreakDate }) => `(${longestStreakDate})`,
     sort: (firstValue, secondValue) => secondValue - firstValue,
   },

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -48,6 +48,7 @@ const useRankingData = () => {
         where('status', '!=', GAME_STATUS.playing),
         orderBy('status', 'desc'),
         orderBy('attempts'),
+        orderBy('solveTime'),
         orderBy('user.name')
       );
       const docs = await getDocs(q);
@@ -56,15 +57,22 @@ const useRankingData = () => {
       let position = 0;
       let currentAttempts = 0;
       let currentStatus = GAME_STATUS.won;
+      let currentSolveTime = 0;
       docs.forEach(doc => {
-        const { attempts, status, ...restDailyResults } = doc.data();
-        if (currentAttempts !== attempts || currentStatus !== status) {
+        const { attempts, solveTime, status, ...restDailyResults } = doc.data();
+        if (
+          currentAttempts !== attempts ||
+          solveTime !== currentSolveTime ||
+          currentStatus !== status
+        ) {
           currentAttempts = attempts;
+          currentSolveTime = solveTime;
           currentStatus = status;
           position += 1;
         }
         results.push({
           attempts,
+          solveTime,
           status,
           ...restDailyResults,
           position,

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -8,6 +8,7 @@ import { GAME_STATUS, RANKING_VALUES, LETTER_STATUS } from 'constants/types';
 import useRankingData from 'hooks/useRankingData';
 
 import './styles.css';
+import { pluralize } from 'utils/helpers';
 
 const WORD_HEIGHT = 40;
 
@@ -36,7 +37,14 @@ const Ranking = () => {
           </TabList>
           <TabPanel>
             {dailyResults.map(
-              ({ attemptedWords, attempts, position, status, user: { email, name, photo } }) => {
+              ({
+                attemptedWords,
+                attempts,
+                position,
+                solveTime,
+                status,
+                user: { email, name, photo },
+              }) => {
                 const isCurrentUser = email === currentUser;
                 const lost = status === GAME_STATUS.lost;
                 const isDisabled = !currentUserPlayed;
@@ -50,6 +58,7 @@ const Ranking = () => {
                     photo={photo}
                     leftText={position}
                     rightText={lost ? 'X' : attempts}
+                    suffix={`(${pluralize(solveTime, 'min')})`}
                     showIcon={currentUserPlayed}
                     expandedHeight={attemptedWords.length * WORD_HEIGHT}
                   >

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,6 +1,7 @@
 export const getCurrentStreakIcon = currentStreak => {
   let icon = '';
-  if (currentStreak < 10) icon = '🤍';
+  if (currentStreak < 1) icon = '💔';
+  else if (currentStreak < 10) icon = '🤍';
   else if (currentStreak < 20) icon = '💛';
   else if (currentStreak < 30) icon = '🧡';
   else if (currentStreak < 40) icon = '💚';

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -47,3 +47,6 @@ export const getTimeDiff = (startDate, endDate, timeFormat = 'minutes') => {
       return Math.round(timeDiff / 1000 / 60);
   }
 };
+
+export const pluralize = (count, noun, suffix = 's') =>
+  `${count} ${noun}${count !== 1 ? suffix : ''}`;


### PR DESCRIPTION
## Links:

[Usar el tiempo como desempate en podio de ranking de hoy](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=Usar%20el%20tiempo%20como%20desempate%20en%20podio%20de%20ranking%20de%20hoy)


## What & Why:

This PR uses the solve Time as a tie breaker in today's ranking when users have the same attempts number (instead of just sharing position and ordering by Name). 

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/8755889/210406631-7049796d-7e31-45d5-95a3-bf892eb90e0a.png">


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
