### PR TITLE
fix: time average left with NAN when guessing at first

### DIFF
--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -178,7 +178,7 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
       const lost = usersAttempts.length === MAX_ATTEMPTS && !won;
       const newStatus = won ? GAME_STATUS.won : lost ? GAME_STATUS.lost : GAME_STATUS.playing;
       const currentTime = getTodaysDate(false);
-      const solveTime = getTimeDiff(dailyResults.startTime, currentTime);
+      const solveTime = getTimeDiff(dailyResults.startTime, currentTime) || 0;
 
       if (!currentRound) {
         const newDailyResults = {
@@ -191,7 +191,7 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
           attempts: 1,
           startTime: currentTime,
           endTime: currentTime,
-          solveTime: 0,
+          solveTime,
           date: today,
           status: won ? GAME_STATUS.won : GAME_STATUS.playing,
           user: {


### PR DESCRIPTION
## Links:
<!--- At a minimum include a link to the Ticket it implements --->


## What & Why:

This PR fixes a bug that when you guessed the word in the first attempt, the time average was left with NAN value.


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
