### PR TITLE
fix: change all outline colors to white, removing blue

### DIFF
--- a/src/components/SideNav/sidenav.css
+++ b/src/components/SideNav/sidenav.css
@@ -33,14 +33,26 @@
   background-color: var(--color-background);
 }
 
+.sideitem:focus {
+  outline: 2px solid var(--color-white);
+}
+
 .selected-item {
   background-color: var(--color-background);
 }
 
 .menuBtn {
+  align-items: center;
   color: var(--color-white);
   background-color: var(--color-transparent);
   border: none;
   cursor: pointer;
+  display: flex;
+  min-height: 44px;
   padding-left: 20px;
+  width: 100%;
+}
+
+.menuBtn:focus {
+  outline: 2px solid var(--color-white);
 }

--- a/src/components/common/Button/styles.css
+++ b/src/components/common/Button/styles.css
@@ -19,3 +19,7 @@
   background-color: var(--color-light-grey);
   cursor: unset;
 }
+
+.button:focus {
+  outline: 2px solid var(--color-white);
+}

--- a/src/components/common/KeyboardLetter/styles.css
+++ b/src/components/common/KeyboardLetter/styles.css
@@ -19,3 +19,7 @@
 .keyboard-letter.disabled {
   cursor: default;
 }
+
+.keyboard-letter:focus {
+  outline: 2px solid var(--color-white);
+}

--- a/src/components/common/LetterInput/styles.css
+++ b/src/components/common/LetterInput/styles.css
@@ -1,5 +1,5 @@
 .letter-input {
-  color: white;
+  color: var(--color-white);
   border-radius: 5px;
   border: 1px solid var(--color-black);
   box-sizing: border-box;
@@ -13,11 +13,15 @@
 }
 
 .letter-input.isSelected {
-  border-color: #eec824;
+  border-color: var(--color-yellow);
   border-style: solid;
   border-width: 2px;
 }
 
 .letter-input.disabled {
   cursor: default;
+}
+
+.letter-input:focus {
+  outline: 2px solid var(--color-white);
 }

--- a/src/components/common/ListRow/styles.css
+++ b/src/components/common/ListRow/styles.css
@@ -37,6 +37,10 @@
   cursor: default;
 }
 
+.list-row-container:focus {
+  outline: 2px solid var(--color-white);
+}
+
 .list-row-left-text {
   flex: 0.15;
   font-size: 24px;

--- a/src/components/common/Tabs/index.js
+++ b/src/components/common/Tabs/index.js
@@ -74,7 +74,6 @@ const Tabs = ({ tabsConfig, defaultIndex }) => {
             role="tabpanel"
             aria-labelledby={`tab-id${index}`}
             id={`panel-id-${index}`}
-            tabIndex={0}
           >
             {tab.content}
           </section>

--- a/src/components/common/Tabs/styles.css
+++ b/src/components/common/Tabs/styles.css
@@ -39,6 +39,10 @@
   background: var(--color-very-dark-green);
 }
 
+.tab:focus {
+  outline: 2px solid var(--color-white);
+}
+
 .tab-panel {
   color: var(--color-white);
   font-weight: 800;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -7,6 +7,7 @@
   --color-dark-green: rgba(83, 141, 78, 0.85);
   --color-medium-green: rgba(83, 141, 78, 0.5);
   --color-green: #538d4e;
+  --color-yellow: #eec824;
   --color-white: #fff;
   --color-medium-red: rgba(210, 62, 62, 0.5);
   --color-red: #d23e3e;


### PR DESCRIPTION
## Links:
<!--- At a minimum include a link to the Ticket it implements --->


## What & Why:

This PR removes the blue outline when a component is selected, instead, it is only white. It also fixes the style for the nav bar arrows.

![](http://g.recordit.co/gQWonFdUMJ.gif)

## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
