### PR TITLE
feat: show error when user is not from Rootstrap

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,11 @@ import './App.css';
 
 function App() {
   const t = useTranslation();
-  const { authenticated } = useAuth();
+  const { authenticated, user } = useAuth();
+
+  const { email = '' } = user || {};
+  const emailDomain = email.split('@')[1];
+  const isRootstrapDomain = emailDomain === 'rootstrap.com';
 
   return (
     <div className="App">
@@ -20,11 +24,16 @@ function App() {
         <title>{t('global.pageTitle')}</title>
       </Helmet>
       <BrowserRouter>
-        {authenticated && <SideNav />}
+        {authenticated && isRootstrapDomain && <SideNav />}
         <main>
           <Switch>
             {routes.map(route => (
-              <RouteFromPath key={`route-${route.path}`} {...route} authenticated={authenticated} />
+              <RouteFromPath
+                key={`route-${route.path}`}
+                {...route}
+                authenticated={authenticated}
+                isRootstrapDomain={isRootstrapDomain}
+              />
             ))}
           </Switch>
         </main>

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import RouteFromPath from 'components/routes/RouteFromPath';
 import SideNav from 'components/SideNav';
 import useTranslation from 'hooks/useTranslation';
 import useAuth from 'hooks/useAuth';
+import useRootstrapAuth from 'hooks/useRootstrapAuth';
 import routes from 'routes';
 
 import 'styles/variables.css';
@@ -12,11 +13,8 @@ import './App.css';
 
 function App() {
   const t = useTranslation();
-  const { authenticated, user } = useAuth();
-
-  const { email = '' } = user || {};
-  const emailDomain = email.split('@')[1];
-  const isRootstrapDomain = emailDomain === 'rootstrap.com';
+  const { authenticated } = useAuth();
+  const { isRootstrapDomain } = useRootstrapAuth();
 
   return (
     <div className="App">

--- a/src/components/LogoutButton/index.js
+++ b/src/components/LogoutButton/index.js
@@ -1,0 +1,31 @@
+import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+
+import Button from 'components/common/Button';
+import firebaseData from 'firebase/firebase';
+import useTranslation from 'hooks/useTranslation';
+import routesPaths from 'routes/routesPaths';
+import { logout } from 'state/actions/userActions';
+
+import './styles.css';
+
+const LogoutButton = () => {
+  const t = useTranslation();
+  const dispatch = useDispatch();
+  const { push } = useHistory();
+  const { logout: firebaseLogout } = firebaseData;
+
+  const handleLogout = async () => {
+    await firebaseLogout();
+    await dispatch(logout());
+    push(routesPaths.login);
+  };
+
+  return (
+    <div className="home-logout">
+      <Button handleClick={handleLogout}>{t('home.logoutBtn')}</Button>
+    </div>
+  );
+};
+
+export default LogoutButton;

--- a/src/components/LogoutButton/styles.css
+++ b/src/components/LogoutButton/styles.css
@@ -1,0 +1,4 @@
+.home-logout {
+  margin: 20px auto;
+  max-width: 15rem;
+}

--- a/src/components/routes/PrivateRoute.js
+++ b/src/components/routes/PrivateRoute.js
@@ -3,13 +3,24 @@ import { Route, Redirect, useLocation } from 'react-router-dom';
 
 import routesPaths from '../../routes/routesPaths';
 
-const PrivateRoute = ({ children, exact = false, path, authenticated }) => {
+const PrivateRoute = ({ children, exact = false, path, authenticated, isRootstrapDomain }) => {
   const location = useLocation();
 
   return authenticated ? (
-    <Route exact={exact} path={path}>
-      {children}
-    </Route>
+    <>
+      {isRootstrapDomain || path === routesPaths.invalidUser ? (
+        <Route exact={exact} path={path}>
+          {children}
+        </Route>
+      ) : (
+        <Redirect
+          to={{
+            pathname: routesPaths.invalidUser,
+            state: { from: location },
+          }}
+        />
+      )}
+    </>
   ) : (
     <Redirect
       to={{

--- a/src/hooks/useRootstrapAuth.js
+++ b/src/hooks/useRootstrapAuth.js
@@ -1,0 +1,13 @@
+import useAuth from 'hooks/useAuth';
+
+const useRootstrapAuth = () => {
+  const { user } = useAuth();
+
+  const { email = '' } = user || {};
+  const emailDomain = email.split('@')[1];
+  const isRootstrapDomain = emailDomain === 'rootstrap.com';
+
+  return { isRootstrapDomain };
+};
+
+export default useRootstrapAuth;

--- a/src/pages/InvalidUser/index.js
+++ b/src/pages/InvalidUser/index.js
@@ -13,7 +13,7 @@ const InvalidUser = () => {
   return (
     <div className="invalid-user">
       <p className="invalid-user-message">
-        {`Lo siento ${name} pero tu email "${email}" no pertenece a Rootstrap.`}{' '}
+        {`Lo siento ${name} pero tu email "${email}" no pertenece a Rootstrap.`}
       </p>
       <p className="invalid-user-message">
         Por favor cerrá sesión y volvé a ingresar con un email "@rootstrap.com"

--- a/src/pages/InvalidUser/index.js
+++ b/src/pages/InvalidUser/index.js
@@ -1,0 +1,26 @@
+import LogoutButton from 'components/LogoutButton';
+import useAuth from 'hooks/useAuth';
+
+import './styles.css';
+
+const InvalidUser = () => {
+  const { user } = useAuth();
+
+  const { email, name: completeName } = user || {};
+
+  const name = completeName?.split(' ')[0];
+
+  return (
+    <div className="invalid-user">
+      <p className="invalid-user-message">
+        {`Lo siento ${name} pero tu email "${email}" no pertenece a Rootstrap.`}{' '}
+      </p>
+      <p className="invalid-user-message">
+        Por favor cerrá sesión y volvé a ingresar con un email "@rootstrap.com"
+      </p>
+      <LogoutButton />
+    </div>
+  );
+};
+
+export default InvalidUser;

--- a/src/pages/InvalidUser/styles.css
+++ b/src/pages/InvalidUser/styles.css
@@ -1,0 +1,15 @@
+.invalid-user {
+  align-items: center;
+  background-color: var(--color-background);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  min-height: 100vh;
+}
+
+.invalid-user-message {
+  color: var(--color-white);
+  font-size: 20px;
+  font-weight: 600;
+}

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -4,7 +4,7 @@ import './styles.css';
 
 const Settings = () => (
   <div className="settings">
-    <h1 className="section-title">Settings in progress...</h1>
+    <h1 className="section-title">Settings</h1>
     <LogoutButton />
   </div>
 );

--- a/src/pages/Settings/index.js
+++ b/src/pages/Settings/index.js
@@ -1,34 +1,12 @@
-import { useHistory } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-
-import Button from 'components/common/Button';
-import firebaseData from 'firebase/firebase';
-import useTranslation from 'hooks/useTranslation';
-import routesPaths from 'routes/routesPaths';
-import { logout } from 'state/actions/userActions';
+import LogoutButton from 'components/LogoutButton';
 
 import './styles.css';
 
-const Settings = () => {
-  const t = useTranslation();
-  const dispatch = useDispatch();
-  const { push } = useHistory();
-  const { logout: firebaseLogout } = firebaseData;
-
-  const handleLogout = async () => {
-    await firebaseLogout();
-    await dispatch(logout());
-    push(routesPaths.login);
-  };
-
-  return (
-    <div className="settings">
-      <h1 className="section-title">Settings in progress...</h1>
-      <div className="home-logout">
-        <Button handleClick={handleLogout}>{t('home.logoutBtn')}</Button>
-      </div>
-    </div>
-  );
-};
+const Settings = () => (
+  <div className="settings">
+    <h1 className="section-title">Settings in progress...</h1>
+    <LogoutButton />
+  </div>
+);
 
 export default Settings;

--- a/src/pages/Settings/styles.css
+++ b/src/pages/Settings/styles.css
@@ -5,8 +5,3 @@
   text-align: center;
   min-height: 100vh;
 }
-
-.home-logout {
-  margin: 20px auto;
-  max-width: 15rem;
-}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,6 @@
 import routesPaths from './routesPaths';
 import Home from 'pages/Home';
+import InvalidUser from 'pages/InvalidUser';
 import Login from 'pages/Login';
 import Ranking from 'pages/Ranking';
 import Rules from 'pages/Rules';
@@ -53,6 +54,10 @@ const routes = [
   {
     path: routesPaths.login,
     component: <Login />,
+  },
+  {
+    path: routesPaths.invalidUser,
+    component: <InvalidUser />,
   },
 ];
 

--- a/src/routes/routesPaths.js
+++ b/src/routes/routesPaths.js
@@ -7,6 +7,7 @@ const routesPaths = {
   users: '/users',
   usersStatistics: '/statistics/:id',
   login: '/login',
+  invalidUser: '/invalidUser',
 };
 
 export default routesPaths;


### PR DESCRIPTION
## Links:

[Ver el tema de acceso solo con email de rootstrap](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=Ver%20el%20tema%20de%20acceso%20solo%20con%20email%20de%20rootstrap)


## What & Why:

This PR adds a new page to redirect users that entered with an email that is not `@rootstrap.com`. These user's don't have access to the db (because of a rule I added), and so they can't play the wordle game. To help them notice what is wrong, now I redirect them to a new `Invalid User` page that only contains a text explaining and a Logout Button. 

![](http://g.recordit.co/OSsJ7lqVs6.gif)

## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
