### PR TITLE
fix: statistics style overflow

### DIFF
--- a/src/components/HorizontalBarChart/index.js
+++ b/src/components/HorizontalBarChart/index.js
@@ -1,4 +1,7 @@
+import cn from 'classnames';
+
 import { MAX_ATTEMPTS } from 'constants/constants';
+
 import './styles.css';
 
 const HorizontalBarChart = ({ data, maxValue, words = false }) => (
@@ -15,15 +18,14 @@ const HorizontalBarChart = ({ data, maxValue, words = false }) => (
         key = value[0];
       }
       const widthPercentage = (numericValue * 100) / maxValue ?? 10;
+      const isEmptyValue = !numericValue;
 
       return (
         <div className="bar-container" key={key}>
           <span className="font-frijole bar-chart-position">{isLostRow ? 'X' : index + 1}</span>
           <div className="bar-chart-value-container">
             <div
-              className={`font-caveat-brush bar-chart-value${
-                isLostRow ? ' bar-chart-value-lost' : ''
-              }`}
+              className={cn('font-caveat-brush bar-chart-value', { isLostRow, isEmptyValue })}
               style={{ width: widthPercentage ? `${widthPercentage}%` : 'fit-content' }}
             >
               {numericValue}

--- a/src/components/HorizontalBarChart/index.js
+++ b/src/components/HorizontalBarChart/index.js
@@ -12,20 +12,21 @@ const HorizontalBarChart = ({ data, maxValue, words = false }) => (
       let numericValue = value;
       let displayValue;
       let key = index;
+      let isLongValue = false;
       if (typeof value !== 'number') {
+        isLongValue = true;
         numericValue = value[1];
         displayValue = value[0];
         key = value[0];
       }
       const widthPercentage = (numericValue * 100) / maxValue ?? 10;
-      const isEmptyValue = !numericValue;
 
       return (
         <div className="bar-container" key={key}>
           <span className="font-frijole bar-chart-position">{isLostRow ? 'X' : index + 1}</span>
           <div className="bar-chart-value-container">
             <div
-              className={cn('font-caveat-brush bar-chart-value', { isLostRow, isEmptyValue })}
+              className={cn('font-caveat-brush bar-chart-value', { isLostRow, isLongValue })}
               style={{ width: widthPercentage ? `${widthPercentage}%` : 'fit-content' }}
             >
               {numericValue}

--- a/src/components/HorizontalBarChart/styles.css
+++ b/src/components/HorizontalBarChart/styles.css
@@ -32,15 +32,14 @@
   margin-left: 15px;
   padding: 5px 10px;
   text-align: right;
-  min-width: 90px;
 }
 
 .bar-chart-value.isLostRow {
   background-color: var(--color-red);
 }
 
-.bar-chart-value.isEmptyValue {
-  min-width: 0px;
+.bar-chart-value.isLongValue {
+  min-width: 95px;
 }
 
 .bar-chart-display-value {

--- a/src/components/HorizontalBarChart/styles.css
+++ b/src/components/HorizontalBarChart/styles.css
@@ -32,10 +32,15 @@
   margin-left: 15px;
   padding: 5px 10px;
   text-align: right;
+  min-width: 90px;
 }
 
-.bar-chart-value-lost {
+.bar-chart-value.isLostRow {
   background-color: var(--color-red);
+}
+
+.bar-chart-value.isEmptyValue {
+  min-width: 0px;
 }
 
 .bar-chart-display-value {


### PR DESCRIPTION
## Links:

[User Statistics visual overflows](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=User%20Statistics%20visual%20overflows)


## What & Why:

This PR adds a `min-width` to the value when the content is a word, since in some cases it was overflowing.

**Before:**

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8755889/211420463-98cbf175-6248-4c27-a257-c6fda1ade07f.png">


**After:**

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/8755889/211420382-4dd1ec36-0d88-4274-a2e1-fdf4e0fcb8c9.png">


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
