### PR TITLE
fix: always accept todays word as valid

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
- * @jpirazusta @ManuViola77 @fernandorosenblit @alandours @gastonri
+ * @jpirazusta @ManuViola77 @fernandorosenblit @alandours @gastonri @jeisux92

--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -327,7 +327,7 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
 
     const isAcceptedWord = ACCEPTED_WORDS.includes(attemptedWord);
     const isTodaysWords = attemptedWord === correctWord;
-    const existsWord = wordExists(attemptedWord) || isAcceptedWord || isTodaysWords;
+    const existsWord = isTodaysWords || isAcceptedWord || wordExists(attemptedWord);
     if (!existsWord) {
       setError(`${attemptedWord.toUpperCase()} doesn't exist in English`);
     } else {

--- a/src/hooks/useUsersAttempts.js
+++ b/src/hooks/useUsersAttempts.js
@@ -326,14 +326,15 @@ const useUsersAttempts = ({ wordLength, correctWord, letters, setLoading }) => {
     }
 
     const isAcceptedWord = ACCEPTED_WORDS.includes(attemptedWord);
-    const existsWord = wordExists(attemptedWord) || isAcceptedWord;
+    const isTodaysWords = attemptedWord === correctWord;
+    const existsWord = wordExists(attemptedWord) || isAcceptedWord || isTodaysWords;
     if (!existsWord) {
       setError(`${attemptedWord.toUpperCase()} doesn't exist in English`);
     } else {
       await compareWithWord(currentAttempt, attemptedWord);
     }
     setWordProcessing(false);
-  }, [compareWithWord, currentRound, usersAttempts, wordLength]);
+  }, [compareWithWord, correctWord, currentRound, usersAttempts, wordLength]);
 
   const focusBefore = letterIndex => {
     if (letterIndex > 0) {


### PR DESCRIPTION
## Links:

[verificar que la palabra de hoy sea siempre valida](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=verificar%20que%20la%20palabra%20de%20hoy%20sea%20siempre%20valida)


## What & Why:

This PR fixes that today's word could not be valid for the `wordExists` validator (if we set a custom word for example). So now with this fix it makes sure that today's word is always considered as existing.

It also adds a codeowner 😄 


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
