### PR TITLE
Fix: Skip to main content button position

### DIFF
--- a/src/components/SkipToMainContent/styles.css
+++ b/src/components/SkipToMainContent/styles.css
@@ -6,6 +6,7 @@
   outline: 2px solid var(--color-white);
   padding: 15px;
   position: absolute;
+  z-index: 1;
 }
 
 .skipToMainContent:focus {


### PR DESCRIPTION
Fix: Skip to main content button position. Button was appearing behind the nav bar.