### PR TITLE
fix: filter top words

### DIFF
--- a/src/hooks/useUsersStatistics.js
+++ b/src/hooks/useUsersStatistics.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { toPairs } from 'lodash';
+import { pickBy, toPairs } from 'lodash';
 
 import { MAX_ATTEMPTS } from 'constants/constants';
 import { getUsersStatistics, updateUsersStatistics } from 'firebase/usersStatistics';
@@ -45,7 +45,8 @@ const useUserStatistics = ({ email, name, photo } = {}) => {
   );
 
   const topAttemptedWords = useMemo(() => {
-    const attemptedWordsArray = toPairs(statistics.attemptedWords).sort((a, b) => b[1] - a[1]);
+    const filteredData = pickBy(statistics.attemptedWords, count => count > 1);
+    const attemptedWordsArray = toPairs(filteredData).sort((a, b) => b[1] - a[1]);
     return attemptedWordsArray.slice(0, MAX_ATTEMPTS + 1);
   }, [statistics.attemptedWords]);
 


### PR DESCRIPTION
## Links:
[arreglar que si un usuario solo hizo la palabra de hoy, ver las estadisticas de ese usuario es spoiler](https://github.com/users/ManuViola77/projects/1/views/1#:~:text=arreglar%20que%20si%20un%20usuario%20solo%20hizo%20la%20palabra%20de%20hoy%2C%20ver%20las%20estadisticas%20de%20ese%20usuario%20es%20spoiler)


## What & Why:
This PR filters the top words so you can only see if the word was used twice or more times


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
