### PR TITLE
fix: multiple calls to firebase for ranking data

### DIFF
--- a/src/hooks/data/useGetRankingData.js
+++ b/src/hooks/data/useGetRankingData.js
@@ -1,0 +1,19 @@
+import { useSelector } from 'react-redux';
+
+const useGetRankingData = () => {
+  const { dailyResults, rankingData, users } = useSelector(
+    ({ ranking: { dailyResults, rankingData, users } }) => ({
+      dailyResults,
+      rankingData,
+      users,
+    })
+  );
+
+  return {
+    dailyResults,
+    rankingData,
+    users,
+  };
+};
+
+export default useGetRankingData;

--- a/src/hooks/endpoints/useRankingEndpoints.js
+++ b/src/hooks/endpoints/useRankingEndpoints.js
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { getAllTimeRankingData, getTodaysResults } from 'firebase/ranking';
+import { getUsers } from 'firebase/users';
+import useGetRankingData from 'hooks/data/useGetRankingData';
+import useConstructor from 'hooks/useConstructor';
+import { setAllTimeRanking, setTodaysResults, setUsersObject } from 'state/actions/rankingActions';
+import { getTodaysDate } from 'utils/helpers';
+
+const useRankingEndpoints = () => {
+  const dispatch = useDispatch();
+
+  const [loading, setLoading] = useState(true);
+  const { users } = useGetRankingData();
+
+  const today = getTodaysDate();
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    const { users } = await getUsers({ isObject: true });
+    await dispatch(setUsersObject({ users }));
+  };
+
+  const fetchTodaysResults = async () => {
+    const { todaysResults } = await getTodaysResults(today);
+    await dispatch(setTodaysResults({ todaysResults }));
+    setLoading(false);
+  };
+
+  const fetchAllTimeRanking = async () => {
+    const { allTimeRankingData } = await getAllTimeRankingData(users);
+    await dispatch(setAllTimeRanking({ allTimeRankingData }));
+  };
+
+  useConstructor(fetchUsers);
+  useConstructor(fetchTodaysResults);
+  useConstructor(fetchAllTimeRanking);
+
+  return { loading };
+};
+
+export default useRankingEndpoints;

--- a/src/hooks/useConstructor.js
+++ b/src/hooks/useConstructor.js
@@ -1,0 +1,13 @@
+import { useRef } from 'react';
+
+const useConstructor = callback => {
+  const hasBeenCalled = useRef(false);
+
+  if (hasBeenCalled.current) return;
+
+  hasBeenCalled.current = true;
+
+  callback();
+};
+
+export default useConstructor;

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -1,50 +1,24 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 import { RANKING_VALUES } from 'constants/types';
-import { getAllTimeRankingData, getTodaysResults } from 'firebase/ranking';
-import { getUsers } from 'firebase/users';
-import { getTodaysDate } from 'utils/helpers';
+import { setAllTimeRanking } from 'state/actions/rankingActions';
 
 import useAuth from './useAuth';
+import useGetRankingData from './data/useGetRankingData';
 
 const useRankingData = () => {
   const {
     user: { email: currentUser },
   } = useAuth();
 
+  const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const [dailyResults, setDailyResults] = useState([]);
-  const [rankingData, setRankingData] = useState([]);
-  const [users, setUsers] = useState({});
-  const [loading, setLoading] = useState(true);
+  const { dailyResults, rankingData } = useGetRankingData();
+
   const [selectedRanking, setSelectedRanking] = useState(RANKING_VALUES[0]);
-
-  const today = getTodaysDate();
-
-  useEffect(() => {
-    (async function () {
-      setLoading(true);
-      const { users: usersResults } = await getUsers({ isObject: true });
-      setUsers(usersResults);
-    })();
-  }, []);
-
-  useEffect(() => {
-    (async function () {
-      const { todaysResults } = await getTodaysResults(today);
-      setDailyResults(todaysResults);
-    })();
-  }, [today]);
-
-  useEffect(() => {
-    (async function () {
-      const { allTimeRankingData } = await getAllTimeRankingData(users);
-      setRankingData(allTimeRankingData);
-      setLoading(false);
-    })();
-  }, [users]);
 
   const currentUserPlayed = useMemo(
     () => dailyResults.find(item => item.user.email === currentUser),
@@ -56,7 +30,7 @@ const useRankingData = () => {
       state: { email, name, photo },
     });
 
-  const onChangeSelectedRanking = newSelectedRanking => {
+  const onChangeSelectedRanking = async newSelectedRanking => {
     if (newSelectedRanking !== selectedRanking) {
       setSelectedRanking(newSelectedRanking);
       let newRankingData = [...rankingData];
@@ -89,7 +63,7 @@ const useRankingData = () => {
           };
         });
 
-      setRankingData(newRankingData);
+      await dispatch(setAllTimeRanking({ allTimeRankingData: newRankingData }));
     }
   };
 
@@ -103,7 +77,6 @@ const useRankingData = () => {
     rankingDataLength,
     dailyResults,
     dailyResultsLength,
-    loading,
     selectedRanking,
     onChangeSelectedRanking,
     goToUsersStatistics,

--- a/src/index.js
+++ b/src/index.js
@@ -24,15 +24,13 @@ const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
-  <React.StrictMode>
-    <IntlProvider messages={flatten(messages)} locale={locale} defaultLocale={DEFAULT_LANGUAGE}>
-      <Provider store={store}>
-        <PersistGate loading={null} persistor={persistor}>
-          <HelmetProvider>
-            <App />
-          </HelmetProvider>
-        </PersistGate>
-      </Provider>
-    </IntlProvider>
-  </React.StrictMode>
+  <IntlProvider messages={flatten(messages)} locale={locale} defaultLocale={DEFAULT_LANGUAGE}>
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        <HelmetProvider>
+          <App />
+        </HelmetProvider>
+      </PersistGate>
+    </Provider>
+  </IntlProvider>
 );

--- a/src/index.js
+++ b/src/index.js
@@ -24,13 +24,15 @@ const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
-  <IntlProvider messages={flatten(messages)} locale={locale} defaultLocale={DEFAULT_LANGUAGE}>
-    <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
-        <HelmetProvider>
-          <App />
-        </HelmetProvider>
-      </PersistGate>
-    </Provider>
-  </IntlProvider>
+  <React.StrictMode>
+    <IntlProvider messages={flatten(messages)} locale={locale} defaultLocale={DEFAULT_LANGUAGE}>
+      <Provider store={store}>
+        <PersistGate loading={null} persistor={persistor}>
+          <HelmetProvider>
+            <App />
+          </HelmetProvider>
+        </PersistGate>
+      </Provider>
+    </IntlProvider>
+  </React.StrictMode>
 );

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import Loading from 'components/common/Loading';
 import Tabs from 'components/common/Tabs';
+import useRankingEndpoints from 'hooks/endpoints/useRankingEndpoints';
 import useRankingData from 'hooks/useRankingData';
 import useTranslation from 'hooks/useTranslation';
 
@@ -10,7 +11,8 @@ import Today from './Today';
 import './styles.css';
 
 const Ranking = () => {
-  const { rankingDataLength, dailyResultsLength, loading } = useRankingData();
+  const { loading } = useRankingEndpoints();
+  const { rankingDataLength, dailyResultsLength } = useRankingData();
 
   const t = useTranslation();
   const allTimeLabel = useMemo(

--- a/src/state/actions/rankingActions.js
+++ b/src/state/actions/rankingActions.js
@@ -1,0 +1,5 @@
+import { createAction } from '@rootstrap/redux-tools';
+
+export const setAllTimeRanking = createAction('SET_ALL_TIME_RANKING');
+export const setTodaysResults = createAction('SET_TODAYS_RESULTS');
+export const setUsersObject = createAction('SET_USERS_OBJECT');

--- a/src/state/reducers/rankingReducer.js
+++ b/src/state/reducers/rankingReducer.js
@@ -1,0 +1,27 @@
+import { createReducer } from '@rootstrap/redux-tools';
+
+import { setAllTimeRanking, setTodaysResults, setUsersObject } from 'state/actions/rankingActions';
+
+const initialState = {
+  dailyResults: [],
+  rankingData: [],
+  users: {},
+};
+
+const handleSetAllTimeRanking = (state, { payload: { allTimeRankingData } }) => {
+  state.rankingData = allTimeRankingData;
+};
+
+const handleSetTodaysResults = (state, { payload: { todaysResults } }) => {
+  state.dailyResults = todaysResults;
+};
+
+const handleSetUsersObject = (state, { payload: { users } }) => {
+  state.users = users;
+};
+
+export default createReducer(initialState, {
+  [setAllTimeRanking]: handleSetAllTimeRanking,
+  [setTodaysResults]: handleSetTodaysResults,
+  [setUsersObject]: handleSetUsersObject,
+});

--- a/src/state/reducers/reducer.js
+++ b/src/state/reducers/reducer.js
@@ -4,6 +4,7 @@ import storage from 'redux-persist/lib/storage';
 
 import { api } from 'services/api';
 
+import rankingReducer from './rankingReducer';
 import statisticsReducer from './statisticsReducer';
 import userReducer from './userReducer';
 
@@ -15,6 +16,7 @@ const sessionPersistConfig = {
 
 const rootReducer = combineReducers({
   [api.reducerPath]: api.reducer,
+  ranking: rankingReducer,
   statistics: statisticsReducer,
   user: persistReducer(sessionPersistConfig, userReducer),
 });


### PR DESCRIPTION
## Links:
[Arreglar llamadas a Firebase para el Ranking](https://github.com/orgs/rootstrap/projects/19/views/1#:~:text=Arreglar%20llamadas%20a%20Firebase%20para%20el%20Ranking)


## What & Why:

This PR fixes that the firebase service was being called many unnecessary times. It can still improve and has to be changed in other parts of the app, but for now, I detected that the Ranking was making lots of unnecessary calls, and since is something the user's like to see I started changing here. 

It separates the `useRankingHook` into 2, so one only access the info and a new one (`useRankingEndpoints`) is the one that calls the endpoints and is only called in one place.

Note that I actually call different services so I still have multiple calls, but each service is only called once.

**Before (Multiple Calls):**

<img width="709" alt="image" src="https://user-images.githubusercontent.com/8755889/221703065-9461efb6-daa2-4724-be19-ff46895c48ca.png">


**After:**

<img width="711" alt="image" src="https://user-images.githubusercontent.com/8755889/221702977-e441920b-ea9a-4d74-9f98-c2546b5cc33a.png">


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
