### PR TITLE
fix: statistics from ranking error

### DIFF
--- a/src/hooks/endpoints/useRankingEndpoints.js
+++ b/src/hooks/endpoints/useRankingEndpoints.js
@@ -4,38 +4,31 @@ import { useDispatch } from 'react-redux';
 import useErrorHandling from 'components/common/RSWordleErrorBoundary/useErrorHandling';
 import { getAllTimeRankingData, getTodaysResults } from 'firebase/ranking';
 import { getUsers } from 'firebase/users';
-import useGetRankingData from 'hooks/data/useGetRankingData';
 import useConstructor from 'hooks/useConstructor';
-import { setAllTimeRanking, setTodaysResults, setUsersObject } from 'state/actions/rankingActions';
+import { setAllTimeRanking, setTodaysResults } from 'state/actions/rankingActions';
 import { getTodaysDate } from 'utils/helpers';
 
 const useRankingEndpoints = () => {
   const dispatch = useDispatch();
 
   const [loading, setLoading] = useState(true);
-  const { users } = useGetRankingData();
   const { triggerError } = useErrorHandling();
 
   const today = getTodaysDate();
 
-  const fetchUsers = async () => {
-    setLoading(true);
-    const { users } = await getUsers({ isObject: true, triggerError });
-    await dispatch(setUsersObject({ users }));
-  };
-
   const fetchTodaysResults = async () => {
+    setLoading(true);
     const { todaysResults } = await getTodaysResults(today, triggerError);
     await dispatch(setTodaysResults({ todaysResults }));
     setLoading(false);
   };
 
   const fetchAllTimeRanking = async () => {
+    const { users } = await getUsers({ isObject: true, triggerError });
     const { allTimeRankingData } = await getAllTimeRankingData(users, triggerError);
     await dispatch(setAllTimeRanking({ allTimeRankingData }));
   };
 
-  useConstructor(fetchUsers);
   useConstructor(fetchTodaysResults);
   useConstructor(fetchAllTimeRanking);
 

--- a/src/state/actions/rankingActions.js
+++ b/src/state/actions/rankingActions.js
@@ -2,4 +2,3 @@ import { createAction } from '@rootstrap/redux-tools';
 
 export const setAllTimeRanking = createAction('SET_ALL_TIME_RANKING');
 export const setTodaysResults = createAction('SET_TODAYS_RESULTS');
-export const setUsersObject = createAction('SET_USERS_OBJECT');

--- a/src/state/reducers/rankingReducer.js
+++ b/src/state/reducers/rankingReducer.js
@@ -1,11 +1,10 @@
 import { createReducer } from '@rootstrap/redux-tools';
 
-import { setAllTimeRanking, setTodaysResults, setUsersObject } from 'state/actions/rankingActions';
+import { setAllTimeRanking, setTodaysResults } from 'state/actions/rankingActions';
 
 const initialState = {
   dailyResults: [],
   rankingData: [],
-  users: {},
 };
 
 const handleSetAllTimeRanking = (state, { payload: { allTimeRankingData } }) => {
@@ -16,12 +15,7 @@ const handleSetTodaysResults = (state, { payload: { todaysResults } }) => {
   state.dailyResults = todaysResults;
 };
 
-const handleSetUsersObject = (state, { payload: { users } }) => {
-  state.users = users;
-};
-
 export default createReducer(initialState, {
   [setAllTimeRanking]: handleSetAllTimeRanking,
   [setTodaysResults]: handleSetTodaysResults,
-  [setUsersObject]: handleSetUsersObject,
 });


### PR DESCRIPTION
## Links:
<!--- At a minimum include a link to the Ticket it implements --->


## What & Why:

This PR fixes an error that the first time the ranking is showing, the users object is empty and that leads to empty photos and ids in the `All Time` Ranking Tab, leading also to empty statistics if a user is tapped. 

Now we get the users collection in the same transaction as getting the info for the All Time Ranking, and since is the only place where we use it we don't need to save it in the reducer, so that was deleted. 

**Before:** 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8755889/222840109-39cbd73e-4acd-4965-95b1-053483b9dde9.png">


**After:**
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/8755889/222840053-405e14f4-4b25-4f43-971a-eb66dcdef5c2.png">


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
