### PR TITLE
feat: add a developers tool to fix broken statistics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ REACT_APP_WORDLE_TEST_CHANNEL_ID=testChannelId
 REACT_APP_USE_TEST_CHANNEL=true/false
 
 REACT_APP_WORDLE_URL=wordleURL
+REACT_APP_ENVIRONMENT=develop/production
 
 # Firebase info taken from project settings
 REACT_APP_FB_API_KEY=

--- a/src/App.js
+++ b/src/App.js
@@ -31,23 +31,30 @@ function App() {
           {showSideNav && <SideNav />}
           <main id={MAIN_ID} {...(showSideNav ? { className: 'page-with-nav' } : {})}>
             <Routes>
-              {routes.map(route => (
-                <Route
-                  key={`route-${route.path}`}
-                  {...route}
-                  element={
-                    <PrivateRoute
-                      {...route}
-                      authenticated={authenticated}
-                      isRootstrapDomain={isRootstrapDomain}
-                    >
-                      <PageWrapper title={route.title} subtitle={route.subtitle}>
-                        {route.element}
-                      </PageWrapper>
-                    </PrivateRoute>
-                  }
-                />
-              ))}
+              {routes.map(route => {
+                const showRoute =
+                  !route.isOnlyDevelop || process.env.REACT_APP_ENVIRONMENT === 'develop';
+
+                if (!showRoute) return null;
+
+                return (
+                  <Route
+                    key={`route-${route.path}`}
+                    {...route}
+                    element={
+                      <PrivateRoute
+                        {...route}
+                        authenticated={authenticated}
+                        isRootstrapDomain={isRootstrapDomain}
+                      >
+                        <PageWrapper title={route.title} subtitle={route.subtitle}>
+                          {route.element}
+                        </PageWrapper>
+                      </PrivateRoute>
+                    }
+                  />
+                );
+              })}
             </Routes>
           </main>
         </RSWordleErrorBoundary>

--- a/src/firebase/dailyResults.js
+++ b/src/firebase/dailyResults.js
@@ -1,4 +1,13 @@
-import { addDoc, collection, doc, getDocs, query, updateDoc, where } from 'firebase/firestore';
+import {
+  addDoc,
+  collection,
+  doc,
+  getDocs,
+  orderBy,
+  query,
+  updateDoc,
+  where,
+} from 'firebase/firestore';
 
 import { DAILY_RESULTS } from 'firebase/collections';
 import firebaseData from 'firebase/firebase';
@@ -16,6 +25,24 @@ export const addDailyResults = async (newDailyResults, triggerError) => {
   } catch (error) {
     console.error(error);
     triggerError({ error });
+  }
+};
+
+export const getAllUsersDailyResults = async (currentUser, triggerError) => {
+  try {
+    const q = query(
+      collection(firebaseDb, DAILY_RESULTS),
+      where('user.email', '==', currentUser),
+      orderBy('date')
+    );
+    const docs = await getDocs(q);
+    return {
+      docs,
+    };
+  } catch (error) {
+    console.error(error);
+    triggerError({ error });
+    return { docs: [] };
   }
 };
 

--- a/src/pages/DeveloperTools/index.js
+++ b/src/pages/DeveloperTools/index.js
@@ -1,0 +1,79 @@
+import Button from 'components/common/Button';
+
+import './styles.css';
+import useDeveloperTools from './useDeveloperTools';
+
+const DeveloperTools = () => {
+  const {
+    statisticsCheck,
+    isLoading,
+    selectedUsers,
+    usersList,
+    toggleSelectedUser,
+    compareStatistics,
+    clearStatisticsCheck,
+    clearSelectedUsers,
+    selectAllUsers,
+  } = useDeveloperTools();
+
+  return (
+    <div className="developer-tools-container">
+      <h1>Tool to help developers!</h1>
+      <div className="developer-tools-users-container">
+        <h2>USERS:</h2>
+        <div className="developer-tools-users-list-container">
+          {usersList?.map(({ email }) => (
+            <div key={`users-${email}`}>
+              <button onClick={() => toggleSelectedUser(email)}>{email} </button>
+            </div>
+          ))}
+        </div>
+        <h2>SELECTED:</h2>
+        <div className="developer-tools-users-list-container">
+          {selectedUsers?.map(email => (
+            <div key={`selected-users-${email}`}>
+              <button onClick={() => toggleSelectedUser(email)}>{email} </button>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="developer-tools-users-container">
+        <div className="developer-tools-button-container">
+          <Button handleClick={selectAllUsers}>Select All Users</Button>
+        </div>
+        <div className="developer-tools-button-container">
+          <Button handleClick={clearSelectedUsers}>Clear Selected Users</Button>
+        </div>
+        <div className="developer-tools-button-container">
+          <Button handleClick={clearStatisticsCheck}>Clear Statistics Check</Button>
+        </div>
+        <div className="developer-tools-button-container">
+          <Button handleClick={compareStatistics}>Compare Statistics</Button>
+        </div>
+      </div>
+      <div className="developer-tools-statistics-resutls">
+        {isLoading ? (
+          <h1>loading...</h1>
+        ) : (
+          <div>
+            {statisticsCheck?.map(({ color, message, handleClickLink }) => (
+              <div className="row-container" key={message}>
+                <h3 style={{ color }}>{message}</h3>
+                {!!handleClickLink && (
+                  <button
+                    className="developer-tools-update-statistics-link"
+                    onClick={handleClickLink}
+                  >
+                    Update Statistics
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DeveloperTools;

--- a/src/pages/DeveloperTools/styles.css
+++ b/src/pages/DeveloperTools/styles.css
@@ -1,0 +1,41 @@
+.developer-tools-container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    padding: 0px 30px
+}
+
+.developer-tools-users-container {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 20px;
+    width: 100%;
+}
+
+.developer-tools-users-list-container {
+    background-color: var(--color-green);
+    height: 300px;
+    overflow-y: scroll;
+    min-width: 300px;
+}
+
+.developer-tools-button-container {
+    align-self: flex-start;
+    margin-top: 30px;
+    margin-left: 30px;
+}
+
+.developer-tools-statistics-resutls {
+    margin-top: 30px;
+}
+
+.developer-tools-update-statistics-link {
+    background-color: transparent;
+    border: none;
+    color: var(--color-red);
+    cursor: pointer;
+    font: inherit;
+    margin-left: 15px;
+    padding: 0;
+    text-decoration: underline;
+}

--- a/src/pages/DeveloperTools/useDeveloperTools.js
+++ b/src/pages/DeveloperTools/useDeveloperTools.js
@@ -1,0 +1,202 @@
+import { useState } from 'react';
+
+import useErrorHandling from 'components/common/RSWordleErrorBoundary/useErrorHandling';
+import { MAX_ATTEMPTS } from 'constants/constants';
+import { getAllUsersDailyResults } from 'firebase/dailyResults';
+import { getUsersStatistics, updateUsersStatistics } from 'firebase/usersStatistics';
+import useUsers from 'hooks/useUsers';
+import { GAME_STATUS } from 'constants/types';
+import { getDisplayDate } from 'utils/helpers';
+
+const EMPTY_STATISTICS = {
+  totalGames: 0,
+  totalWins: 0,
+  totalAttempts: Array(MAX_ATTEMPTS + 1).fill(0),
+  currentStreak: 0,
+  lastDatePlayed: '',
+  longestStreak: 0,
+  longestStreakDate: '',
+  attemptedWords: {},
+  timeAverage: 0,
+  minTime: 0,
+  maxTime: 0,
+};
+
+const useDeveloperTools = () => {
+  const [selectedUsers, setSelectedUsers] = useState([]);
+  const [statisticsCheck, setStatisticsCheck] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const { usersList } = useUsers();
+
+  const { triggerError } = useErrorHandling();
+
+  const toggleSelectedUser = user => {
+    const isSelectedUser = !!selectedUsers.find(email => email === user);
+
+    setSelectedUsers(previous => {
+      if (isSelectedUser) {
+        return previous.filter(email => email !== user);
+      }
+
+      const newSelectedUsers = [...previous];
+      newSelectedUsers.push(user);
+      return newSelectedUsers;
+    });
+  };
+
+  const processResults = ({
+    currentStatistics: {
+      totalGames,
+      totalWins,
+      totalAttempts,
+      currentStreak,
+      longestStreak,
+      attemptedWords,
+      longestStreakDate,
+      timeAverage,
+      minTime,
+      maxTime,
+    },
+    attemptedWords: usersAttempts,
+    attempts,
+    date,
+    solveTime,
+    status,
+  }) => {
+    const won = status === GAME_STATUS.won;
+    const totalAttemptsIndex = won ? attempts - 1 : MAX_ATTEMPTS;
+    const newCurrentStreak = won ? currentStreak + 1 : 0;
+    const newTotalAttempts = [...totalAttempts];
+    newTotalAttempts[totalAttemptsIndex] = totalAttempts[totalAttemptsIndex] + 1;
+    const newAttemptedWords = { ...attemptedWords };
+    usersAttempts.forEach(({ word }) => {
+      const currentValue = newAttemptedWords[word] ?? 0;
+      newAttemptedWords[word] = currentValue + 1;
+    });
+    const year = Number(date.substring(0, 4));
+    const month = Number(date.substring(4, 6));
+    const monthIndex = month - 1;
+    const day = Number(date.substring(6, 8));
+    const lastDatePlayed = getDisplayDate(new Date(year, monthIndex, day));
+
+    const newStatistics = {
+      totalGames: totalGames + 1,
+      totalWins: won ? totalWins + 1 : totalWins,
+      totalAttempts: newTotalAttempts,
+      currentStreak: newCurrentStreak,
+      longestStreak: newCurrentStreak > longestStreak ? newCurrentStreak : longestStreak,
+      attemptedWords: newAttemptedWords,
+      lastDatePlayed,
+      longestStreakDate: newCurrentStreak >= longestStreak ? lastDatePlayed : longestStreakDate,
+      timeAverage: Math.round((timeAverage * totalGames + solveTime) / (totalGames + 1)),
+      minTime: solveTime < minTime ? solveTime : minTime,
+      maxTime: solveTime > maxTime ? solveTime : maxTime,
+    };
+
+    return newStatistics;
+  };
+
+  const compareStatistics = async () => {
+    setIsLoading(true);
+    if (!selectedUsers.length) {
+      alert('No Users Selected');
+    }
+
+    const newStatisticsCheck = [];
+
+    await Promise.all(
+      selectedUsers.map(async email => {
+        let expectedStatistics = EMPTY_STATISTICS;
+
+        const { currentStatistics } = await getUsersStatistics(email, triggerError);
+        const { docs } = await getAllUsersDailyResults(email, triggerError);
+
+        docs.forEach(doc => {
+          const { status, ...restOfData } = doc.data();
+          if (status !== GAME_STATUS.playing) {
+            expectedStatistics = processResults({
+              currentStatistics: expectedStatistics,
+              status,
+              ...restOfData,
+            });
+          }
+        });
+
+        const objectDiff = (obj1, obj2) =>
+          Object.fromEntries(
+            Object.entries(obj1).filter(([key, value]) => {
+              if (typeof value === 'object') {
+                const objectComp = objectDiff(value, obj2[key]);
+                const isDifferentValue = Object.keys(objectComp).length > 0;
+                return isDifferentValue;
+              }
+              return value !== obj2[key];
+            })
+          );
+
+        const statisticsDifference = objectDiff(expectedStatistics, currentStatistics);
+
+        const isDifferent = Object.keys(statisticsDifference).length > 0;
+
+        const errorConsoleLog = () => {
+          console.warn(email);
+          console.log('statisticsDifference (expected): ', statisticsDifference);
+          Object.entries(statisticsDifference).forEach(([key, value]) => {
+            if (typeof value === 'object') {
+              console.log(`${key}:`);
+              console.log('expected ', value);
+              console.log('found ', currentStatistics[key]);
+            } else {
+              console.log(`${key}: expected ${value} -> found ${currentStatistics[key]}`);
+            }
+          });
+        };
+
+        if (isDifferent) {
+          errorConsoleLog();
+        }
+
+        newStatisticsCheck.push({
+          color: isDifferent ? '#d23e3e' : '#538d4e',
+          message: `${email} -> ${isDifferent ? '❌' : '✅'}`,
+          handleClickLink: isDifferent
+            ? async () => {
+                errorConsoleLog();
+                if (
+                  window.confirm(
+                    `Are you sure you want to update statistics for ${email}? Please check the console log to make sure of the changes you are going to make`
+                  )
+                )
+                  await updateUsersStatistics(expectedStatistics, email, triggerError);
+              }
+            : undefined,
+        });
+      })
+    );
+
+    setStatisticsCheck(newStatisticsCheck);
+    setIsLoading(false);
+  };
+
+  const clearStatisticsCheck = () => setStatisticsCheck([]);
+  const clearSelectedUsers = () => setSelectedUsers([]);
+
+  const selectAllUsers = () => {
+    const newSelectedUsers = [...usersList];
+    setSelectedUsers(newSelectedUsers.map(({ email }) => email));
+  };
+
+  return {
+    statisticsCheck,
+    isLoading,
+    selectedUsers,
+    usersList,
+    toggleSelectedUser,
+    compareStatistics,
+    clearStatisticsCheck,
+    clearSelectedUsers,
+    selectAllUsers,
+  };
+};
+
+export default useDeveloperTools;

--- a/src/pages/DeveloperTools/useDeveloperTools.js
+++ b/src/pages/DeveloperTools/useDeveloperTools.js
@@ -138,7 +138,7 @@ const useDeveloperTools = () => {
 
         const isDifferent = Object.keys(statisticsDifference).length > 0;
 
-        const errorConsoleLog = () => {
+        const errorConsoleLog = (showUpdateWarning = false) => {
           console.warn(email);
           console.log('statisticsDifference (expected): ', statisticsDifference);
           Object.entries(statisticsDifference).forEach(([key, value]) => {
@@ -150,6 +150,12 @@ const useDeveloperTools = () => {
               console.log(`${key}: expected ${value} -> found ${currentStatistics[key]}`);
             }
           });
+          if (showUpdateWarning) {
+            console.log(
+              'You will be changing the current statistics with these values: ',
+              expectedStatistics
+            );
+          }
         };
 
         if (isDifferent) {
@@ -161,7 +167,7 @@ const useDeveloperTools = () => {
           message: `${email} -> ${isDifferent ? '❌' : '✅'}`,
           handleClickLink: isDifferent
             ? async () => {
-                errorConsoleLog();
+                errorConsoleLog(true);
                 if (
                   window.confirm(
                     `Are you sure you want to update statistics for ${email}? Please check the console log to make sure of the changes you are going to make`

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,4 +1,5 @@
 import routesPaths from './routesPaths';
+import DeveloperTools from 'pages/DeveloperTools';
 import Home from 'pages/Home';
 import InvalidUser from 'pages/InvalidUser';
 import Login from 'pages/Login';
@@ -63,6 +64,12 @@ const routes = [
   {
     path: routesPaths.invalidUser,
     element: <InvalidUser />,
+    isPrivate: true,
+  },
+  {
+    path: routesPaths.developerTools,
+    element: <DeveloperTools />,
+    isOnlyDevelop: true,
     isPrivate: true,
   },
 ];

--- a/src/routes/routesPaths.js
+++ b/src/routes/routesPaths.js
@@ -9,6 +9,7 @@ const routesPaths = {
   usersStatistics: '/statistics/:id',
   login: '/login',
   invalidUser: '/invalidUser',
+  developerTools: '/developerTools',
 };
 
 export default routesPaths;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -32,7 +32,9 @@ export const getTodaysDate = (shouldFormat = true) => {
   return shouldFormat ? formatDate(today) : today.toString();
 };
 
-export const getTodaysDisplayDate = () => new Date().toLocaleString('en').split(',')[0];
+export const getDisplayDate = date => date.toLocaleString('en').split(',')[0];
+
+export const getTodaysDisplayDate = () => getDisplayDate(new Date());
 
 export const getTimeDiff = (startDate, endDate, timeFormat = 'minutes') => {
   const dateTimeEnd = new Date(endDate);


### PR DESCRIPTION
## Links:



## What & Why:

This PR adds a special hidden screen named `Developers Tools` (only available in the development environment and only by URL - no menu option to enter). For now,  is to easily check if the user's statistics are ok and in case they are not it offers the possibility of fixing it. For this, it calculates what the statistics should be and it checks what they currently are, comparing these two things. 

The statistics difference is due to some bugs that we had when it come to production, with older users. We shouldn't need to use this anymore (I already fixed the broken cases), but I want to leave it just in case. Once in a while, we can check if the statistics are correct for each user. 

The UI is just functional, not pretty. 

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/8755889/223282262-35890de3-2657-4941-ba6c-eeef40fa5a63.png">


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
