### PR TITLE
Hotfix: Grab date from server

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,5 @@
+import { Timestamp } from 'firebase/firestore';
+
 export const getCurrentStreakIcon = currentStreak => {
   let icon = '';
   if (currentStreak < 1) icon = '💔';
@@ -27,7 +29,7 @@ const formatDate = date => {
 };
 
 export const getTodaysDate = (shouldFormat = true) => {
-  const today = new Date();
+  const today = Timestamp.now().toDate();
 
   return shouldFormat ? formatDate(today) : today.toString();
 };

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,4 +1,4 @@
-import { Timestamp } from 'firebase/firestore';
+import { serverTimestamp } from 'firebase/firestore';
 
 export const getCurrentStreakIcon = currentStreak => {
   let icon = '';
@@ -29,7 +29,7 @@ const formatDate = date => {
 };
 
 export const getTodaysDate = (shouldFormat = true) => {
-  const today = Timestamp.now().toDate();
+  const today = new Date(serverTimestamp() * 1000);
 
   return shouldFormat ? formatDate(today) : today.toString();
 };


### PR DESCRIPTION
## Links:
<!--- At a minimum include a link to the Ticket it implements --->


## What & Why:
<!--- Describe the changes being made and why they're useful --->
Currently, the date used for fetching the daily word is taken from browsers date, using a `new Date()`.
This generates a bug in which the user can change their OS's date and complete past and previous wordles.

<!--- Screenshots are expected for UI changes... right? ಠ_ಠ --->


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [x] Safe to Revert *check this box if this PR can be reverted without incident*
