### PR TITLE
fix: clean reducer data when the user logs out

### DIFF
--- a/src/state/reducers/rankingReducer.js
+++ b/src/state/reducers/rankingReducer.js
@@ -1,6 +1,7 @@
 import { createReducer } from '@rootstrap/redux-tools';
 
 import { setAllTimeRanking, setTodaysResults } from 'state/actions/rankingActions';
+import { logout } from 'state/actions/userActions';
 
 const initialState = {
   dailyResults: [],
@@ -15,7 +16,12 @@ const handleSetTodaysResults = (state, { payload: { todaysResults } }) => {
   state.dailyResults = todaysResults;
 };
 
+const handleLogout = () => {
+  return initialState;
+};
+
 export default createReducer(initialState, {
+  [logout]: handleLogout,
   [setAllTimeRanking]: handleSetAllTimeRanking,
   [setTodaysResults]: handleSetTodaysResults,
 });

--- a/src/state/reducers/statisticsReducer.js
+++ b/src/state/reducers/statisticsReducer.js
@@ -1,8 +1,9 @@
 import { createReducer } from '@rootstrap/redux-tools';
 
 import { setUserStatistics } from 'state/actions/statisticsActions';
+import { logout } from 'state/actions/userActions';
 
-const initialState = {
+export const initialState = {
   statistics: {},
 };
 
@@ -10,6 +11,11 @@ const handleSetUsersStatistics = (state, { payload: { statistics, selectedUser }
   state.statistics = { ...state.statistics, [selectedUser]: statistics };
 };
 
+const handleLogout = () => {
+  return initialState;
+};
+
 export default createReducer(initialState, {
+  [logout]: handleLogout,
   [setUserStatistics]: handleSetUsersStatistics,
 });

--- a/src/state/reducers/statisticsReducer.js
+++ b/src/state/reducers/statisticsReducer.js
@@ -3,7 +3,7 @@ import { createReducer } from '@rootstrap/redux-tools';
 import { setUserStatistics } from 'state/actions/statisticsActions';
 import { logout } from 'state/actions/userActions';
 
-export const initialState = {
+const initialState = {
   statistics: {},
 };
 

--- a/src/state/reducers/userReducer.js
+++ b/src/state/reducers/userReducer.js
@@ -19,7 +19,7 @@ const handleSetOnboardingShown = state => {
 };
 
 const handleLogout = () => {
-  return { ...initialState };
+  return initialState;
 };
 
 export default createReducer(initialState, {


### PR DESCRIPTION
## Links:
<!--- At a minimum include a link to the Ticket it implements --->


## What & Why:
This PR adds the logout handler to all the reducers to go back to their initial state.
This will prevent a current bug where empty statistics keep set empty when the user actually has statistics


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
